### PR TITLE
SUP-1952: Enable using Environment Variables to configure Wiz API Secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ steps:
 
 ### `api-secret-env` (Optional, string)
 
-The environment variable that the Wiz API Secret is stored in. Defaults to using `WIZ_API_SECRET`.
+The environment variable that the Wiz API Secret is stored in. Defaults to using `WIZ_API_SECRET`. Refer to the [documentation](https://buildkite.com/docs/pipelines/secrets#using-a-secrets-storage-service) for more information about managing secrets on your Buildkite agents.
 
 ### `scan-type` (Required, string) : 'docker | iac'
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ steps:
 
 ## Configuration
 
+### `api-secret-env` (Optional, string)
+
+The environment variable that the Wiz API Secret is stored in. Defaults to using `WIZ_API_SECRET`.
+
 ### `scan-type` (Required, string) : 'docker | iac'
 The scan type can be either docker or iac
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ steps:
 The environment variable that the Wiz API Secret is stored in. Defaults to using `WIZ_API_SECRET`.
 
 ### `scan-type` (Required, string) : 'docker | iac'
+
 The scan type can be either docker or iac
 
 ### `image-address` (Optional, string)

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -21,16 +21,22 @@ if [ "${SCAN_TYPE}" = "iac" ] && [[ -z "${BUILDKITE_PLUGIN_WIZ_PATH:-}" ]]; then
     exit 1
 fi
 
+api_secret_var="${BUILDKITE_PLUGIN_WIZ_API_SECRET_ENV:-WIZ_API_SECRET}"
+
+if [[ -z "${!api_secret_var:-}" ]] ; then
+  echo "+++ 🚨 No Wiz API Secret password found in \$${api_secret_var}"
+  exit 1
+fi
+
 #TODO move this to agent-startup so all agents have wiz setup to save time, possibly directly as cli
 setupWiz() {
     echo "Setting up and authenticating wiz"
     mkdir -p "$WIZ_DIR"
-    WIZ_API_SECRET=$(aws secretsmanager get-secret-value --secret-id global/buildkite/wiz-api-secret --query "SecretString" --output text)
     docker run \
         --rm -it \
         --mount type=bind,src="$WIZ_DIR",dst=/cli \
         wiziocli.azurecr.io/wizcli:latest-amd64 \
-        auth --id="$WIZ_API_ID" --secret "$WIZ_API_SECRET"
+        auth --id="$WIZ_API_ID" --secret "$api_secret_var"
     # check that wiz-auth work expected, and a file in WIZ_DIR is created
     if [ -z "$(ls -A "$WIZ_DIR")" ]; then
         echo "Wiz authentication failed, please confirm that credentials are set for WIZ_API_ID and WIZ_API_SECRET"

--- a/plugin.yml
+++ b/plugin.yml
@@ -6,6 +6,8 @@ requirements:
   - docker
 configuration:
   properties:
+    api-secret-env:
+      type: string
     image-address:
       type: string
     path:

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -5,10 +5,13 @@ load "$BATS_PLUGIN_PATH/load.bash"
 # Uncomment the following line to debug stub failures
 # export BUILDKITE_AGENT_STUB_DEBUG=/dev/tty
 
-@test "Authenticates to wiz using \$WIZ_API_SECRET" {
+setup () {
   export BUILDKITE_PLUGIN_WIZ_SCAN_TYPE="docker"
   export BUILDKITE_PLUGIN_WIZ_IMAGE_ADDRESS="ubuntu:22.04"
   export WIZ_DIR="$HOME/.wiz"
+}
+
+@test "Authenticates to wiz using \$WIZ_API_SECRET" {
   export WIZ_API_ID="test"
   export WIZ_API_SECRET="secret"
 
@@ -26,9 +29,6 @@ load "$BATS_PLUGIN_PATH/load.bash"
 }
 
 @test "Authenticates to wiz using \$BUILDKITE_PLUGIN_WIZ_API_SECRET_ENV" {
-  export BUILDKITE_PLUGIN_WIZ_SCAN_TYPE="docker"
-  export BUILDKITE_PLUGIN_WIZ_IMAGE_ADDRESS="ubuntu:22.04"
-  export WIZ_DIR="$HOME/.wiz"
   export WIZ_API_ID="test"
   export BUILDKITE_PLUGIN_WIZ_API_SECRET_ENV="CUSTOM_WIZ_API_SECRET_ENV"
   export CUSTOM_WIZ_API_SECRET_ENV="secret"
@@ -47,8 +47,6 @@ load "$BATS_PLUGIN_PATH/load.bash"
 }
 
 @test "No Wiz API Secret password found in \$WIZ_API_SECRET" {
-  export BUILDKITE_PLUGIN_WIZ_SCAN_TYPE="docker"
-  export BUILDKITE_PLUGIN_WIZ_IMAGE_ADDRESS="ubuntu:22.04"
   export WIZ_API_ID="test"
   export WIZ_API_SECRET=""
 
@@ -59,8 +57,6 @@ load "$BATS_PLUGIN_PATH/load.bash"
 }
 
 @test "No Wiz API Secret password found in \$CUSTOM_WIZ_API_SECRET_ENV" {
-  export BUILDKITE_PLUGIN_WIZ_SCAN_TYPE="docker"
-  export BUILDKITE_PLUGIN_WIZ_IMAGE_ADDRESS="ubuntu:22.04"
   export WIZ_API_ID="test"
   export BUILDKITE_PLUGIN_WIZ_API_SECRET_ENV="CUSTOM_WIZ_API_SECRET_ENV"
   export CUSTOM_WIZ_API_SECRET_ENV=""

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -66,3 +66,11 @@ setup () {
   assert_output --partial "No Wiz API Secret password found in $CUSTOM_WIZ_API_SECRET_ENV"
   assert_failure
 }
+
+@test "Missing scan type" {
+  export BUILDKITE_PLUGIN_WIZ_SCAN_TYPE=""
+
+  run "$PWD/hooks/post-command"
+  assert_output "Missing scan type. Possible values: 'iac', 'docker'"
+  assert_failure 
+}

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -3,7 +3,7 @@
 load "$BATS_PLUGIN_PATH/load.bash"
 
 # Uncomment the following line to debug stub failures
-export BUILDKITE_AGENT_STUB_DEBUG=/dev/tty
+# export BUILDKITE_AGENT_STUB_DEBUG=/dev/tty
 
 @test "Authenticates to wiz using \$WIZ_API_SECRET" {
   export BUILDKITE_PLUGIN_WIZ_SCAN_TYPE="docker"

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -5,13 +5,13 @@ load "$BATS_PLUGIN_PATH/load.bash"
 # Uncomment the following line to debug stub failures
 export BUILDKITE_AGENT_STUB_DEBUG=/dev/tty
 
-@test "Authenticates to wiz" {
+@test "Authenticates to wiz using \$WIZ_API_SECRET" {
   export BUILDKITE_PLUGIN_WIZ_SCAN_TYPE="docker"
   export BUILDKITE_PLUGIN_WIZ_IMAGE_ADDRESS="ubuntu:22.04"
   export WIZ_DIR="$HOME/.wiz"
   export WIZ_API_ID="test"
+  export WIZ_API_SECRET="secret"
 
-  stub aws 'echo test-key'
   stub docker 'echo TODO'
   mkdir -p "$WIZ_DIR"
   touch "$WIZ_DIR/key"
@@ -23,4 +23,50 @@ export BUILDKITE_AGENT_STUB_DEBUG=/dev/tty
   assert_success
   #cleanup
   rm "$WIZ_DIR/key"
+}
+
+@test "Authenticates to wiz using \$BUILDKITE_PLUGIN_WIZ_API_SECRET_ENV" {
+  export BUILDKITE_PLUGIN_WIZ_SCAN_TYPE="docker"
+  export BUILDKITE_PLUGIN_WIZ_IMAGE_ADDRESS="ubuntu:22.04"
+  export WIZ_DIR="$HOME/.wiz"
+  export WIZ_API_ID="test"
+  export BUILDKITE_PLUGIN_WIZ_API_SECRET_ENV="CUSTOM_WIZ_API_SECRET_ENV"
+  export CUSTOM_WIZ_API_SECRET_ENV="secret"
+
+  stub docker 'echo TODO'
+  mkdir -p "$WIZ_DIR"
+  touch "$WIZ_DIR/key"
+
+  run "$PWD/hooks/post-command"
+
+  assert_output --partial "Authenticated successfully"
+  #todo test docker scan
+  assert_success
+  #cleanup
+  rm "$WIZ_DIR/key"
+}
+
+@test "No Wiz API Secret password found in \$WIZ_API_SECRET" {
+  export BUILDKITE_PLUGIN_WIZ_SCAN_TYPE="docker"
+  export BUILDKITE_PLUGIN_WIZ_IMAGE_ADDRESS="ubuntu:22.04"
+  export WIZ_API_ID="test"
+  export WIZ_API_SECRET=""
+
+  run "$PWD/hooks/post-command"
+
+  assert_output --partial "No Wiz API Secret password found in $WIZ_API_SECRET"
+  assert_failure
+}
+
+@test "No Wiz API Secret password found in \$CUSTOM_WIZ_API_SECRET_ENV" {
+  export BUILDKITE_PLUGIN_WIZ_SCAN_TYPE="docker"
+  export BUILDKITE_PLUGIN_WIZ_IMAGE_ADDRESS="ubuntu:22.04"
+  export WIZ_API_ID="test"
+  export BUILDKITE_PLUGIN_WIZ_API_SECRET_ENV="CUSTOM_WIZ_API_SECRET_ENV"
+  export CUSTOM_WIZ_API_SECRET_ENV=""
+
+  run "$PWD/hooks/post-command"
+
+  assert_output --partial "No Wiz API Secret password found in $CUSTOM_WIZ_API_SECRET_ENV"
+  assert_failure
 }


### PR DESCRIPTION
To allow use other other Secrets Managers, allowed choosing with Environment Variable should be used which contains the the Wiz API Secret. Defaults to using `WIZ_API_SECRET` but the `api-secret-env` plugin config allows switching to any defined Environment Variable.