### PR TITLE
feat: Add scanning of Terraform Files and Plans

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,52 @@ steps:
           path: "infrastructure/cdk.out"
 ```
 
+### Terraform Files Scanning
+
+Add the following to your `pipeline.yml`, the plugin will scan a specific Terraform File and related Parameter file.
+
+```yaml
+steps:
+  - label: "Scan Terraform File"
+    env:
+    - WIZ_API_ID: "<your-id-goes-here>"
+    plugins:
+      - wiz#v1.1.0:
+          scan-type: 'terraform-files'
+          file-path: 'main.tf'
+          parameter-files: 'variables.tf'
+```
+
+By default, `file-path` will be the root of your repository, and scan all Terraform files in the directory.
+To change the directory, add the following to your `pipeline.yml`, the plugin will scan the chosen directory.
+
+```yaml
+steps:
+  - label: "Scan Terraform Files in Directory"
+    env:
+    - WIZ_API_ID: "<your-id-goes-here>"
+    plugins:
+      - wiz#v1.1.0:
+          scan-type: 'terraform-files'
+          file-path: 'my-terraform-files'
+```
+
+### Terraform Plan Scanning
+
+Add the following to your `pipeline.yml`, the plugin will scan a Terraform Plan.
+
+```yaml
+steps:
+  - label: "Scan Terraform Plan"
+    command: terraform plan -out plan.tfplan && terraform show -json plan.tfplan | jq -er . > plan.tfplanjson
+    env:
+    - WIZ_API_ID: "<your-id-goes-here>"
+    plugins:
+      - wiz#v1.1.0:
+          scan-type: 'terraform-plan'
+          file-path: 'plan.tfplanjson'
+```
+
 ## Configuration
 
 ### `api-secret-env` (Optional, string)

--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ steps:
 
 The environment variable that the Wiz API Secret is stored in. Defaults to using `WIZ_API_SECRET`. Refer to the [documentation](https://buildkite.com/docs/pipelines/secrets#using-a-secrets-storage-service) for more information about managing secrets on your Buildkite agents.
 
-### `scan-type` (Required, string) : 'docker | iac'
+### `scan-type` (Required, string) : 'docker | iac | terraform-files | terraform-plan'
 
-The scan type can be either docker or iac
+The type of resource to be scanned.
 
 ### `image-address` (Optional, string)
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ steps:
 
 The environment variable that the Wiz API Secret is stored in. Defaults to using `WIZ_API_SECRET`. Refer to the [documentation](https://buildkite.com/docs/pipelines/secrets#using-a-secrets-storage-service) for more information about managing secrets on your Buildkite agents.
 
+### `file-path` (Optional, string)
+
+The file or directory to scan, defaults to the root directory of repository.
+Used when `scan-type` is `terraform-files` and `terraform-plan`.
+
 ### `scan-type` (Required, string) : 'docker | iac | terraform-files | terraform-plan'
 
 The type of resource to be scanned.
@@ -62,6 +67,11 @@ The type of resource to be scanned.
 ### `image-address` (Optional, string)
 
 The path to image file, if the `scan-type` is `docker`
+
+### `parameter-files` (Optional, string)
+
+Comma separated list of globs of external parameter files to include while scanning e.g., `variables.tf`
+Used when `scan-type` is `terraform-files`.
 
 ### `path` (Optional, string)
 

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -7,7 +7,7 @@ SCAN_TYPE="${BUILDKITE_PLUGIN_WIZ_SCAN_TYPE:-}"
 CDK_PATH="${BUILDKITE_PLUGIN_WIZ_PATH:-}"
 
 if [[ -z "${SCAN_TYPE}" ]]; then
-    echo "Missing scan type. Possible values: 'iac', 'docker'"
+    echo "Missing scan type. Possible values: 'iac', 'docker', 'terraform-files', 'terraform-plan'"
     exit 1
 fi
 

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -145,10 +145,10 @@ terraformFilesScan() {
     exit_code="$?"
     case $exit_code in
     0)
-        buildAnnotation "Terraform Files" "$BUILDKITE_LABEL" true "result/output" | buildkite-agent annotate --append --context 'ctx-wiz-iac-success' --style 'success'
+        buildAnnotation "Terraform Files" "$BUILDKITE_LABEL" true "result/output" | buildkite-agent annotate --append --context 'ctx-wiz-terraform-files-success' --style 'success'
         ;;
     *)
-        buildAnnotation "Terraform Files" "$BUILDKITE_LABEL" false "result/output" | buildkite-agent annotate --append --context 'ctx-wiz-iac-warning' --style 'warning'
+        buildAnnotation "Terraform Files" "$BUILDKITE_LABEL" false "result/output" | buildkite-agent annotate --append --context 'ctx-wiz-terraform-files-warning' --style 'warning'
         ;;
     esac
     # buildkite-agent artifact upload "result/**/*" --log-level info
@@ -171,10 +171,10 @@ terraformPlanScan() {
     exit_code="$?"
     case $exit_code in
     0)
-        buildAnnotation "Terraform Plan" "$BUILDKITE_LABEL" true "result/output" | buildkite-agent annotate --append --context 'ctx-wiz-iac-success' --style 'success'
+        buildAnnotation "Terraform Plan" "$BUILDKITE_LABEL" true "result/output" | buildkite-agent annotate --append --context 'ctx-wiz-terraform-plan-success' --style 'success'
         ;;
     *)
-        buildAnnotation "Terraform Plan" "$BUILDKITE_LABEL" false "result/output" | buildkite-agent annotate --append --context 'ctx-wiz-iac-warning' --style 'warning'
+        buildAnnotation "Terraform Plan" "$BUILDKITE_LABEL" false "result/output" | buildkite-agent annotate --append --context 'ctx-wiz-terraform-plan-warning' --style 'warning'
         ;;
     esac
     # buildkite-agent artifact upload "result/**/*" --log-level info

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -5,6 +5,8 @@ set -uo pipefail
 WIZ_DIR="$HOME/.wiz"
 SCAN_TYPE="${BUILDKITE_PLUGIN_WIZ_SCAN_TYPE:-}"
 CDK_PATH="${BUILDKITE_PLUGIN_WIZ_PATH:-}"
+FILE_PATH="${BUILDKITE_PLUGIN_WIZ_FILE_PATH:-}"
+PARAMETER_FILES="${BUILDKITE_PLUGIN_WIZ_PARAMETER_FILES:-}"
 
 if [[ -z "${SCAN_TYPE}" ]]; then
     echo "Missing scan type. Possible values: 'iac', 'docker', 'terraform-files', 'terraform-plan'"
@@ -24,8 +26,8 @@ fi
 api_secret_var="${BUILDKITE_PLUGIN_WIZ_API_SECRET_ENV:-WIZ_API_SECRET}"
 
 if [[ -z "${!api_secret_var:-}" ]]; then
-  echo "+++ 🚨 No Wiz API Secret password found in \$${api_secret_var}"
-  exit 1
+    echo "+++ 🚨 No Wiz API Secret password found in \$${api_secret_var}"
+    exit 1
 fi
 
 #TODO move this to agent-startup so all agents have wiz setup to save time, possibly directly as cli
@@ -123,8 +125,30 @@ iacScan() {
 }
 
 terraformFilesScan() {
-    # TODO: complete functionaility using Wiz CLI docker image
-    true
+    mkdir -p result
+    docker run \
+        --rm -it \
+        --mount type=bind,src="$WIZ_DIR",dst=/cli,readonly \
+        --mount type=bind,src="$PWD",dst=/scan \
+        wiziocli.azurecr.io/wizcli:latest-amd64 \
+        iac scan \
+        --name "$BUILDKITE_JOB_ID" -f human -o /scan/result/output,human \
+        --types 'Terraform' \
+        --path "/scan/$FILE_PATH" \
+        --parameter-files "${PARAMETER_FILES}"
+
+    exit_code="$?"
+    case $exit_code in
+    0)
+        buildAnnotation "Terraform Files" "$BUILDKITE_LABEL" true "result/output" | buildkite-agent annotate --append --context 'ctx-wiz-iac-success' --style 'success'
+        ;;
+    *)
+        buildAnnotation "Terraform Files" "$BUILDKITE_LABEL" false "result/output" | buildkite-agent annotate --append --context 'ctx-wiz-iac-warning' --style 'warning'
+        ;;
+    esac
+    # buildkite-agent artifact upload "result/**/*" --log-level info
+    # this post step will be used in template to check the step was run
+    echo "${BUILDKITE_BUILD_ID}" >check-file && buildkite-agent artifact upload check-file
 }
 
 terraformPlanScan() {

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -23,7 +23,7 @@ fi
 
 api_secret_var="${BUILDKITE_PLUGIN_WIZ_API_SECRET_ENV:-WIZ_API_SECRET}"
 
-if [[ -z "${!api_secret_var:-}" ]] ; then
+if [[ -z "${!api_secret_var:-}" ]]; then
   echo "+++ 🚨 No Wiz API Secret password found in \$${api_secret_var}"
   exit 1
 fi
@@ -119,7 +119,7 @@ iacScan() {
     esac
     # buildkite-agent artifact upload "result/**/*" --log-level info
     # this post step will be used in template to check the step was run
-    echo "${BUILDKITE_BUILD_ID}" > check-file && buildkite-agent artifact upload check-file
+    echo "${BUILDKITE_BUILD_ID}" >check-file && buildkite-agent artifact upload check-file
 }
 
 terraformFilesScan() {

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -122,6 +122,16 @@ iacScan() {
     echo "${BUILDKITE_BUILD_ID}" > check-file && buildkite-agent artifact upload check-file
 }
 
+terraformFilesScan() {
+    # TODO: complete functionaility using Wiz CLI docker image
+    true
+}
+
+terraformPlanScan() {
+    # TODO: complete functionaility using Wiz CLI docker image
+    true
+}
+
 case "${SCAN_TYPE}" in
 iac)
     setupWiz
@@ -130,5 +140,13 @@ iac)
 docker)
     setupWiz
     dockerImageScan
+    ;;
+terraform-files)
+    setupWiz
+    terraformFilesScan
+    ;;
+terraform-plan)
+    setupWiz
+    terraformPlanScan
     ;;
 esac

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -23,6 +23,11 @@ if [ "${SCAN_TYPE}" = "iac" ] && [[ -z "${BUILDKITE_PLUGIN_WIZ_PATH:-}" ]]; then
     exit 1
 fi
 
+if [ "${SCAN_TYPE}" = "terraform-plan" ] && [[ -z "${FILE_PATH}" ]]; then
+    echo "+++ 🚨 file-path must be specified to Terraform Plan file when scan-type is 'terraform-plan'"
+    exit 1
+fi
+
 api_secret_var="${BUILDKITE_PLUGIN_WIZ_API_SECRET_ENV:-WIZ_API_SECRET}"
 
 if [[ -z "${!api_secret_var:-}" ]]; then
@@ -152,8 +157,29 @@ terraformFilesScan() {
 }
 
 terraformPlanScan() {
-    # TODO: complete functionaility using Wiz CLI docker image
-    true
+    mkdir -p result
+    docker run \
+        --rm -it \
+        --mount type=bind,src="$WIZ_DIR",dst=/cli,readonly \
+        --mount type=bind,src="$PWD",dst=/scan \
+        wiziocli.azurecr.io/wizcli:latest-amd64 \
+        iac scan \
+        --name "$BUILDKITE_JOB_ID" -f human -o /scan/result/output,human \
+        --types 'Terraform' \
+        --path "/scan/$FILE_PATH"
+
+    exit_code="$?"
+    case $exit_code in
+    0)
+        buildAnnotation "Terraform Plan" "$BUILDKITE_LABEL" true "result/output" | buildkite-agent annotate --append --context 'ctx-wiz-iac-success' --style 'success'
+        ;;
+    *)
+        buildAnnotation "Terraform Plan" "$BUILDKITE_LABEL" false "result/output" | buildkite-agent annotate --append --context 'ctx-wiz-iac-warning' --style 'warning'
+        ;;
+    esac
+    # buildkite-agent artifact upload "result/**/*" --log-level info
+    # this post step will be used in template to check the step was run
+    echo "${BUILDKITE_BUILD_ID}" >check-file && buildkite-agent artifact upload check-file
 }
 
 case "${SCAN_TYPE}" in

--- a/plugin.yml
+++ b/plugin.yml
@@ -17,6 +17,8 @@ configuration:
       enum:
         - docker
         - iac
+        - terraform-files
+        - terraform-plan
   required:
     - scan-type
   additionalProperties: false

--- a/plugin.yml
+++ b/plugin.yml
@@ -8,7 +8,11 @@ configuration:
   properties:
     api-secret-env:
       type: string
+    file-path:
+      type: string
     image-address:
+      type: string
+    parameter-files:
       type: string
     path:
       type: string

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -71,6 +71,6 @@ setup () {
   export BUILDKITE_PLUGIN_WIZ_SCAN_TYPE=""
 
   run "$PWD/hooks/post-command"
-  assert_output "Missing scan type. Possible values: 'iac', 'docker'"
+  assert_output "Missing scan type. Possible values: 'iac', 'docker', 'terraform-files', 'terraform-plan'"
   assert_failure 
 }

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -5,7 +5,7 @@ load "$BATS_PLUGIN_PATH/load.bash"
 # Uncomment the following line to debug stub failures
 # export BUILDKITE_AGENT_STUB_DEBUG=/dev/tty
 
-setup () {
+setup() {
   export BUILDKITE_PLUGIN_WIZ_SCAN_TYPE="docker"
   export BUILDKITE_PLUGIN_WIZ_IMAGE_ADDRESS="ubuntu:22.04"
   export WIZ_DIR="$HOME/.wiz"
@@ -72,5 +72,5 @@ setup () {
 
   run "$PWD/hooks/post-command"
   assert_output "Missing scan type. Possible values: 'iac', 'docker', 'terraform-files', 'terraform-plan'"
-  assert_failure 
+  assert_failure
 }

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -74,3 +74,12 @@ setup() {
   assert_output "Missing scan type. Possible values: 'iac', 'docker', 'terraform-files', 'terraform-plan'"
   assert_failure
 }
+
+@test "Terraform Plan scan without File specified" {
+  export BUILDKITE_PLUGIN_WIZ_SCAN_TYPE="terraform-plan"
+  export BUILDKITE_PLUGIN_WIZ_FILE_PATH=""
+
+  run "$PWD/hooks/post-command"
+  assert_output --partial "file-path must be specified to Terraform Plan file when scan-type is 'terraform-plan'"
+  assert_failure
+}


### PR DESCRIPTION
Expanding the capabilities of the Plugin to be able to scan both Terraform Files and Plans.
Using existing setup/style that will be refactored in a separate PR to avoid bloat and too many changes.