### PR TITLE
fix: plugin captures docker exit code and exits on non-0 status

### DIFF
--- a/hooks/post-command
+++ b/hooks/post-command
@@ -89,24 +89,18 @@ dockerImageScan() {
         -f human \
         -o /scan/result,human,true
     exit_code="$?"
-
-    # If docker exits with a non-0, we should exit with that code and stop running
-    if [[ exit_code -ne 0 ]]; then
-        exit ${exit_code}
-    fi
     image_name=$(echo "$IMAGE" | cut -d "/" -f 2)
     # FIXME: Linktree Specific Env. Var.
     # buildkite-agent artifact upload result --log-level info
     case $exit_code in
     0)
         buildAnnotation "docker" "$image_name" true "$PWD/result" | buildkite-agent annotate --append --style 'success' --context 'ctx-wiz-docker-success'
-        exit 0
         ;;
     *)
         buildAnnotation "docker" "$image_name" false "$PWD/result" | buildkite-agent annotate --append --context 'ctx-wiz-docker-warning' --style 'warning'
-        exit 0
         ;;
     esac
+    exit $exit_code
 }
 
 iacScan() {
@@ -132,6 +126,8 @@ iacScan() {
     # buildkite-agent artifact upload "result/**/*" --log-level info
     # this post step will be used in template to check the step was run
     echo "${BUILDKITE_BUILD_ID}" >check-file && buildkite-agent artifact upload check-file
+
+    exit $exit_code
 }
 
 terraformFilesScan() {
@@ -159,6 +155,7 @@ terraformFilesScan() {
     # buildkite-agent artifact upload "result/**/*" --log-level info
     # this post step will be used in template to check the step was run
     echo "${BUILDKITE_BUILD_ID}" >check-file && buildkite-agent artifact upload check-file
+    exit $exit_code
 }
 
 terraformPlanScan() {
@@ -185,6 +182,7 @@ terraformPlanScan() {
     # buildkite-agent artifact upload "result/**/*" --log-level info
     # this post step will be used in template to check the step was run
     echo "${BUILDKITE_BUILD_ID}" >check-file && buildkite-agent artifact upload check-file
+    exit $exit_code
 }
 
 case "${SCAN_TYPE}" in

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -89,6 +89,11 @@ dockerImageScan() {
         -f human \
         -o /scan/result,human,true
     exit_code="$?"
+
+    # If docker exits with a non-0, we should exit with that code and stop running
+    if [[ exit_code -ne 0 ]]; then
+        exit ${exit_code}
+    fi
     image_name=$(echo "$IMAGE" | cut -d "/" -f 2)
     # FIXME: Linktree Specific Env. Var.
     # buildkite-agent artifact upload result --log-level info

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -5,17 +5,36 @@ load "$BATS_PLUGIN_PATH/load.bash"
 # Uncomment the following line to debug stub failures
 # export BUILDKITE_AGENT_STUB_DEBUG=/dev/tty
 
-setup() {
+
+setup () {
   export BUILDKITE_PLUGIN_WIZ_SCAN_TYPE="docker"
   export BUILDKITE_PLUGIN_WIZ_IMAGE_ADDRESS="ubuntu:22.04"
   export WIZ_DIR="$HOME/.wiz"
+}
+
+@test "Captures docker exit code and exits plugin when non-0 status" {
+
+  export WIZ_API_ID="test"
+  export WIZ_API_SECRET="secret"
+
+  stub docker : 'exit 1'
+  mkdir -p "$WIZ_DIR"
+  touch "$WIZ_DIR/key"
+
+  run "$PWD/hooks/post-command"
+  #todo test docker scan
+  assert_failure
+  #cleanup
+  rm "$WIZ_DIR/key"
 }
 
 @test "Authenticates to wiz using \$WIZ_API_SECRET" {
   export WIZ_API_ID="test"
   export WIZ_API_SECRET="secret"
 
-  stub docker 'echo TODO'
+  stub docker : 'exit 0'
+  stub docker : 'exit 0'
+  stub docker : 'exit 0'
   mkdir -p "$WIZ_DIR"
   touch "$WIZ_DIR/key"
 
@@ -33,7 +52,7 @@ setup() {
   export BUILDKITE_PLUGIN_WIZ_API_SECRET_ENV="CUSTOM_WIZ_API_SECRET_ENV"
   export CUSTOM_WIZ_API_SECRET_ENV="secret"
 
-  stub docker 'echo TODO'
+  stub docker : 'exit 0'
   mkdir -p "$WIZ_DIR"
   touch "$WIZ_DIR/key"
 


### PR DESCRIPTION
The plugin would capture the exit code from `docker run`, however would just swallow the error and continue running even on failure. With this fix, we capture the exit code and on a non-0 exit from docker, the plugin will exit with the captured exit code.