### PR TITLE
SUP-2264: Correct Unbound Variable 

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Add the following to your `pipeline.yml`, the plugin will scan a specific CloudF
 ```yaml
 steps:
   - label: "Scan CloudFormation template file"
+    command: ls
     env:
     - WIZ_API_ID: "<your-id-goes-here>"
     plugins:
@@ -77,6 +78,7 @@ Add the following to your `pipeline.yml`, the plugin will scan a specific Terraf
 ```yaml
 steps:
   - label: "Scan Terraform File"
+    command: ls *.tf
     env:
     - WIZ_API_ID: "<your-id-goes-here>"
     plugins:
@@ -93,6 +95,7 @@ To change the directory, add the following to your `pipeline.yml`, the plugin wi
 ```yaml
 steps:
   - label: "Scan Terraform Files in Directory"
+    command: ls my-terraform-dir/*.tf
     env:
     - WIZ_API_ID: "<your-id-goes-here>"
     plugins:

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -134,7 +134,7 @@ iacScan() {
         -f human \
         -o /scan/result/output,human \
         --name "$BUILDKITE_JOB_ID" \
-        --path "/scan/$FILE_PATH" "${args[@]}"
+        --path "/scan/$FILE_PATH" "${!args[@]}"
 
     exit_code="$?"
     case $exit_code in


### PR DESCRIPTION
As `"${args[@]}"` gets expanded, there are some situation where the array would be empty and result in `args[@]: unbound variable`
By adding `!` in front of the variable, if it is empty it will expand to null and won't result in an error and failing the plugin.

Additionally, adding `command:` to example steps as was missing