### PR TITLE
Fixed IAC scan docker command

### DIFF
--- a/hooks/post-command
+++ b/hooks/post-command
@@ -134,7 +134,7 @@ iacScan() {
         -f human \
         -o /scan/result/output,human \
         --name "$BUILDKITE_JOB_ID" \
-        --path "/scan/$FILE_PATH" "${!args[@]}"
+        --path "/scan/$FILE_PATH" "${args[@]}"
 
     exit_code="$?"
     case $exit_code in


### PR DESCRIPTION
There was a typo in the Docker command which was causing bad arguments to be used.  I just removed a '!' and it's all working now.