### PR TITLE
SUP-2264-2: Correct 'unbound variable' on array expansion

### DIFF
--- a/hooks/post-command
+++ b/hooks/post-command
@@ -35,6 +35,14 @@ if [[ -n "${PARAMETER_FILES}" ]]; then
     args+=("--parameter-files=${PARAMETER_FILES}")
 fi
 
+# check if the args array is not empty and expand parameters into string
+# else use an empty string, to avoid 'unbound variable' on expansion of arrays if empty
+
+cmd_args=""
+if [[ "${#args[@]}" -ne 0 ]]; then
+    cmd_args+="${args[*]}"
+fi
+
 # Get the architecture of the machine for running the container image due to "latest" not being multi-architecture
 # Available images: `latest`, `latest-amd64` and `latest-arm64`
 # therefore default case will use `latest`
@@ -134,7 +142,7 @@ iacScan() {
         -f human \
         -o /scan/result/output,human \
         --name "$BUILDKITE_JOB_ID" \
-        --path "/scan/$FILE_PATH" "${args[@]}"
+        --path "/scan/$FILE_PATH" "${cmd_args}"
 
     exit_code="$?"
     case $exit_code in

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -39,14 +39,6 @@ if [[ -n "${PARAMETER_FILES}" ]]; then
     args+=("--parameter-files=${PARAMETER_FILES}")
 fi
 
-# check if the args array is not empty and expand parameters into string
-# else use an empty string, to avoid 'unbound variable' on expansion of arrays if empty
-
-cmd_args=""
-if [[ "${#args[@]}" -ne 0 ]]; then
-    cmd_args+="${args[*]}"
-fi
-
 # Get the architecture of the machine for running the container image due to "latest" not being multi-architecture
 # Available images: `latest`, `latest-amd64` and `latest-arm64`
 # therefore default case will use `latest`
@@ -146,7 +138,7 @@ iacScan() {
         -f human \
         -o /scan/result/output,human \
         --name "$BUILDKITE_JOB_ID" \
-        --path "/scan/$FILE_PATH" "${cmd_args}"
+        --path "/scan/$FILE_PATH" ${args:+"${args[@]}"}
 
     exit_code="$?"
     case $exit_code in

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -8,8 +8,6 @@ FILE_PATH="${BUILDKITE_PLUGIN_WIZ_PATH:-}"
 PARAMETER_FILES="${BUILDKITE_PLUGIN_WIZ_PARAMETER_FILES:-}"
 IAC_TYPE="${BUILDKITE_PLUGIN_WIZ_IAC_TYPE:-}"
 
-args=()
-
 if [[ -z "${SCAN_TYPE}" ]]; then
     echo "Missing scan type. Possible values: 'iac', 'docker'"
     exit 1
@@ -26,6 +24,12 @@ if [[ -z "${!api_secret_var:-}" ]]; then
     echo "+++ 🚨 No Wiz API Secret password found in \$${api_secret_var}"
     exit 1
 fi
+
+##
+# Wiz CLI Parameters
+##
+
+args=()
 
 if [[ -n "${IAC_TYPE}" ]]; then
     args+=("--types=${IAC_TYPE}")


### PR DESCRIPTION
Misunderstanding by myself on how `${!args[@]}` works and missed when locally testing the parameter expansion when there are values in the array in https://github.com/buildkite-plugins/wiz-buildkite-plugin/pull/15

Updated to not substitute `args` if it is null/empty therefore not producing an empty string, else expand `args` to give the expect Wiz CLI Parameters. See docs for details:

> ${parameter:+word}
> 
>     If parameter is null or unset, nothing is substituted, otherwise the expansion of word is substituted. 

https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html 

Adding a section to gather all the Wiz CLI parameters under for when new ones are added.