### PR TITLE
SUP-2288: Add Directory Scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ steps:
     env:
     - WIZ_API_ID: "<your-id-goes-here>"
     plugins:
-      - wiz#v1.3.2:
+      - wiz#v1.3.3:
           scan-type: 'dir'
           path: 'main.tf'
 ```
@@ -148,7 +148,7 @@ steps:
     env:
     - WIZ_API_ID: "<your-id-goes-here>"
     plugins:
-      - wiz#v1.3.2:
+      - wiz#v1.3.3:
           scan-type: 'dir'
           path: 'my-dir'
 ```

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Used when `scan-type` is `dir` or `iac`.
 
 ### `show-secret-snippets` (Optional, bool)
 
-Enable snippets in secrets. 
+Enable snippets in secrets.
 Defaults to: `false`
 
 ## Developing

--- a/README.md
+++ b/README.md
@@ -141,6 +141,11 @@ Used when `scan-type` is `iac`.
 
 The path to image file, if the `scan-type` is `docker`.
 
+### `output-format` (Optional, string): `human | json | sarif`
+
+Scans output format.
+Defaults to: `human`
+
 ### `parameter-files` (Optional, string)
 
 Comma separated list of globs of external parameter files to include while scanning e.g., `variables.tf`
@@ -150,6 +155,11 @@ Used when `scan-type` is `iac`.
 
 The file or directory to scan, defaults to the root directory of repository.
 Used when `scan-type` is `dir` or `iac`.
+
+### `show-secret-snippets` (Optional, bool)
+
+Enable snippets in secrets. 
+Defaults to: `false`
 
 ## Developing
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ steps:
 
 The environment variable that the Wiz API Secret is stored in. Defaults to using `WIZ_API_SECRET`. Refer to the [documentation](https://buildkite.com/docs/pipelines/secrets#using-a-secrets-storage-service) for more information about managing secrets on your Buildkite agents.
 
-### `scan-type` (Required, string) : 'docker | iac'
+### `scan-type` (Required, string) : `dir | docker | iac'
 
 The type of resource to be scanned.
 
@@ -149,7 +149,7 @@ Used when `scan-type` is `iac`.
 ### `path` (Optional, string)
 
 The file or directory to scan, defaults to the root directory of repository.
-Used when `scan-type` is `iac`.
+Used when `scan-type` is `dir` or `iac`.
 
 ## Developing
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,37 @@ steps:
           path: 'plan.tfplanjson'
 ```
 
+### Directory Scanning
+
+Add the following to your `pipeline.yml`, the plugin will scan a directory.
+
+```yaml
+steps:
+  - label: "Scan Directory"
+    command: ls .
+    env:
+    - WIZ_API_ID: "<your-id-goes-here>"
+    plugins:
+      - wiz#v1.3.2:
+          scan-type: 'dir'
+          path: 'main.tf'
+```
+
+By default, `path` parameter will be the root of your repository, and scan all files in the local directory.
+To change the directory, add the following to your `pipeline.yml`, the plugin will scan the chosen directory.
+
+```yaml
+steps:
+  - label: "Scan Files in different Directory"
+    command: ls my-dir
+    env:
+    - WIZ_API_ID: "<your-id-goes-here>"
+    plugins:
+      - wiz#v1.3.2:
+          scan-type: 'dir'
+          path: 'my-dir'
+```
+
 ## Configuration
 
 ### `api-secret-env` (Optional, string)

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -156,6 +156,34 @@ iacScan() {
     exit $exit_code
 }
 
+dirScan() {
+    mkdir -p result
+    docker run \
+        --rm -it \
+        --mount type=bind,src="$WIZ_DIR",dst=/cli,readonly \
+        --mount type=bind,src="$PWD",dst=/scan \
+        "${wiz_cli_container}" \
+        dir scan \
+        -o /scan/result/output,human \
+        --name "$BUILDKITE_JOB_ID" \
+        --path "/scan/$FILE_PATH" ${args:+"${args[@]}"}
+
+    exit_code="$?"
+    case $exit_code in
+    0)
+        buildAnnotation "dir" "$BUILDKITE_LABEL" true "result/output" | buildkite-agent annotate --append --context 'ctx-wiz-dir-success' --style 'success'
+        ;;
+    *)
+        buildAnnotation "dir" "$BUILDKITE_LABEL" false "result/output" | buildkite-agent annotate --append --context 'ctx-wiz-dir-warning' --style 'warning'
+        ;;
+    esac
+    # buildkite-agent artifact upload "result/**/*" --log-level info
+    # this post step will be used in template to check the step was run
+    echo "${BUILDKITE_BUILD_ID}" >check-file && buildkite-agent artifact upload check-file
+
+    exit $exit_code
+}
+
 case "${SCAN_TYPE}" in
 iac)
     setupWiz

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -11,7 +11,7 @@ OUTPUT_FORMAT="${BUILDKITE_PLUGIN_WIZ_OUTPUT_FORMAT:=human}"
 SHOW_SECRET_SNIPPETS="${BUILDKITE_PLUGIN_WIZ_SHOW_SECRET_SNIPPETS:=false}"
 
 if [[ -z "${SCAN_TYPE}" ]]; then
-    echo "Missing scan type. Possible values: 'iac', 'docker'"
+    echo "+++ 🚨 Missing scan type. Possible values: 'iac', 'docker', 'dir'"
     exit 1
 fi
 

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -16,7 +16,7 @@ if [[ -z "${SCAN_TYPE}" ]]; then
 fi
 
 if [[ "${SCAN_TYPE}" == "docker" && -z "${BUILDKITE_PLUGIN_WIZ_IMAGE_ADDRESS:-}" ]]; then
-    echo "+++ 🚨 Missing image address, docker scans require an adress to pull the image"
+    echo "+++ 🚨 Missing image address, docker scans require an address to pull the image"
     exit 1
 fi
 

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -165,4 +165,8 @@ docker)
     setupWiz
     dockerImageScan
     ;;
+dir)
+    setupWiz
+    dirScan
+    ;;
 esac

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -15,7 +15,7 @@ if [[ -z "${SCAN_TYPE}" ]]; then
     exit 1
 fi
 
-if [ "${SCAN_TYPE}" = "docker" ] && [[ -z "${BUILDKITE_PLUGIN_WIZ_IMAGE_ADDRESS:-}" ]]; then
+if [[ "${SCAN_TYPE}" == "docker" && -z "${BUILDKITE_PLUGIN_WIZ_IMAGE_ADDRESS:-}" ]]; then
     echo "Missing image address, docker scans require an adress to pull the image"
     exit 1
 fi

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -48,12 +48,17 @@ else
     exit 1
 fi
 
+## IAC Scanning Parameters
+
+if [[ "${SCAN_TYPE}" == "iac" ]]; then
+
 if [[ -n "${IAC_TYPE}" ]]; then
     args+=("--types=${IAC_TYPE}")
 fi
 
 if [[ -n "${PARAMETER_FILES}" ]]; then
     args+=("--parameter-files=${PARAMETER_FILES}")
+    fi
 fi
 
 # Get the architecture of the machine for running the container image due to "latest" not being multi-architecture

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -7,6 +7,8 @@ SCAN_TYPE="${BUILDKITE_PLUGIN_WIZ_SCAN_TYPE:-}"
 FILE_PATH="${BUILDKITE_PLUGIN_WIZ_PATH:-}"
 PARAMETER_FILES="${BUILDKITE_PLUGIN_WIZ_PARAMETER_FILES:-}"
 IAC_TYPE="${BUILDKITE_PLUGIN_WIZ_IAC_TYPE:-}"
+OUTPUT_FORMAT="${BUILDKITE_PLUGIN_WIZ_OUTPUT_FORMAT:=human}"
+SHOW_SECRET_SNIPPETS="${BUILDKITE_PLUGIN_WIZ_SHOW_SECRET_SNIPPETS:=false}"
 
 if [[ -z "${SCAN_TYPE}" ]]; then
     echo "Missing scan type. Possible values: 'iac', 'docker'"
@@ -30,6 +32,21 @@ fi
 ##
 
 args=()
+
+## Global Parameters
+
+if [[ "${SHOW_SECRET_SNIPPETS}" == "true" ]]; then
+    args+=("--show-secret-snippets")
+fi
+
+output_formats=("human" "json" "sarif")
+if [[ ${output_formats[*]} =~ ${OUTPUT_FORMAT} ]]; then
+    args+=("--format=${OUTPUT_FORMAT}")
+else
+    echo "+++ 🚨 Invalid Output Format: ${OUTPUT_FORMAT}"
+    echo "Valid Formats: ${output_formats[*]}"
+    exit 1
+fi
 
 if [[ -n "${IAC_TYPE}" ]]; then
     args+=("--types=${IAC_TYPE}")

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -52,12 +52,12 @@ fi
 
 if [[ "${SCAN_TYPE}" == "iac" ]]; then
 
-if [[ -n "${IAC_TYPE}" ]]; then
-    args+=("--types=${IAC_TYPE}")
-fi
+    if [[ -n "${IAC_TYPE}" ]]; then
+        args+=("--types=${IAC_TYPE}")
+    fi
 
-if [[ -n "${PARAMETER_FILES}" ]]; then
-    args+=("--parameter-files=${PARAMETER_FILES}")
+    if [[ -n "${PARAMETER_FILES}" ]]; then
+        args+=("--parameter-files=${PARAMETER_FILES}")
     fi
 fi
 
@@ -132,8 +132,8 @@ dockerImageScan() {
         "${wiz_cli_container}" \
         docker scan --image "$IMAGE" \
         --policy-hits-only \
-        -f human \
-        -o /scan/result,human,true
+        -o /scan/result,human,true ${args:+"${args[@]}"}
+
     exit_code="$?"
     image_name=$(echo "$IMAGE" | cut -d "/" -f 2)
     # FIXME: Linktree Specific Env. Var.
@@ -157,7 +157,6 @@ iacScan() {
         --mount type=bind,src="$PWD",dst=/scan \
         "${wiz_cli_container}" \
         iac scan \
-        -f human \
         -o /scan/result/output,human \
         --name "$BUILDKITE_JOB_ID" \
         --path "/scan/$FILE_PATH" ${args:+"${args[@]}"}

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -16,7 +16,7 @@ if [[ -z "${SCAN_TYPE}" ]]; then
 fi
 
 if [[ "${SCAN_TYPE}" == "docker" && -z "${BUILDKITE_PLUGIN_WIZ_IMAGE_ADDRESS:-}" ]]; then
-    echo "Missing image address, docker scans require an adress to pull the image"
+    echo "+++ 🚨 Missing image address, docker scans require an adress to pull the image"
     exit 1
 fi
 

--- a/plugin.yml
+++ b/plugin.yml
@@ -10,6 +10,12 @@ configuration:
       type: string
     image-address:
       type: string
+    output-format:
+      type: string
+      enum:
+        - human
+        - json
+        - sarif
     parameter-files:
       type: string
     path:
@@ -18,7 +24,9 @@ configuration:
       type: string
       enum:
         - docker
-        - iac
+        - iac  
+    show-secret-snippets:
+      type: bool
     iac-type:
       type: string
       enum:

--- a/plugin.yml
+++ b/plugin.yml
@@ -27,7 +27,8 @@ configuration:
         - docker
         - iac  
     show-secret-snippets:
-      type: bool
+      type: boolean
+      default: false
     iac-type:
       type: string
       enum:

--- a/plugin.yml
+++ b/plugin.yml
@@ -16,6 +16,7 @@ configuration:
         - human
         - json
         - sarif
+      default: human
     parameter-files:
       type: string
     path:

--- a/plugin.yml
+++ b/plugin.yml
@@ -23,6 +23,7 @@ configuration:
     scan-type:
       type: string
       enum:
+        - dir
         - docker
         - iac  
     show-secret-snippets:

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -66,11 +66,11 @@ setup() {
 
 @test "No Wiz API Secret password found in \$WIZ_API_SECRET" {
   export WIZ_API_ID="test"
-  export WIZ_API_SECRET=""
+  unset WIZ_API_SECRET
 
   run "$PWD/hooks/post-command"
 
-  assert_output --partial "No Wiz API Secret password found in $WIZ_API_SECRET"
+  assert_output "+++ 🚨 No Wiz API Secret password found in \$WIZ_API_SECRET"
   assert_failure
 }
 
@@ -81,7 +81,7 @@ setup() {
 
   run "$PWD/hooks/post-command"
 
-  assert_output --partial "No Wiz API Secret password found in $CUSTOM_WIZ_API_SECRET_ENV"
+  assert_output "+++ 🚨 No Wiz API Secret password found in \$CUSTOM_WIZ_API_SECRET_ENV"
   assert_failure
 }
 
@@ -89,6 +89,6 @@ setup() {
   export BUILDKITE_PLUGIN_WIZ_SCAN_TYPE=""
 
   run "$PWD/hooks/post-command"
-  assert_output "Missing scan type. Possible values: 'iac', 'docker'"
+  assert_output "+++ 🚨 Missing scan type. Possible values: 'iac', 'docker', 'dir'"
   assert_failure
 }

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -5,8 +5,7 @@ load "$BATS_PLUGIN_PATH/load.bash"
 # Uncomment the following line to debug stub failures
 # export BUILDKITE_AGENT_STUB_DEBUG=/dev/tty
 
-
-setup () {
+setup() {
   export BUILDKITE_PLUGIN_WIZ_SCAN_TYPE="docker"
   export BUILDKITE_PLUGIN_WIZ_IMAGE_ADDRESS="ubuntu:22.04"
   export WIZ_DIR="$HOME/.wiz"

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -99,7 +99,7 @@ setup() {
   unset BUILDKITE_PLUGIN_WIZ_IMAGE_ADDRESS
 
   run "$PWD/hooks/post-command"
-  assert_output "+++ 🚨 Missing image address, docker scans require an adress to pull the image"
+  assert_output "+++ 🚨 Missing image address, docker scans require an address to pull the image"
 
   assert_failure
 }

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -103,3 +103,13 @@ setup() {
 
   assert_failure
 }
+
+@test "Invalid Output Format" {
+  export WIZ_API_SECRET="secret"
+  export BUILDKITE_PLUGIN_WIZ_OUTPUT_FORMAT="wrong-format"
+
+  run "$PWD/hooks/post-command"
+  assert_output --partial "+++ 🚨 Invalid Output Format: $BUILDKITE_PLUGIN_WIZ_OUTPUT_FORMAT"
+  
+  assert_failure
+}

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -92,3 +92,14 @@ setup() {
   assert_output "+++ 🚨 Missing scan type. Possible values: 'iac', 'docker', 'dir'"
   assert_failure
 }
+
+@test "Docker Scan without BUILDKITE_PLUGIN_WIZ_IMAGE_ADDRESS" {
+  export WIZ_API_ID="test"
+  export WIZ_API_SECRET="secret"
+  unset BUILDKITE_PLUGIN_WIZ_IMAGE_ADDRESS
+
+  run "$PWD/hooks/post-command"
+  assert_output "+++ 🚨 Missing image address, docker scans require an adress to pull the image"
+
+  assert_failure
+}


### PR DESCRIPTION
Adding directory scanning and refactoring parameters that are used across all the different scans, this is to allow for future refactoring of the 3 scans and more flexibility to match the available options via the Wiz CLI.

Updated error messages to match styling and tests to be more stringent to capture code changes.