### PR TITLE
fix: align docker scan output with other scan types.

### DIFF
--- a/hooks/post-command
+++ b/hooks/post-command
@@ -120,6 +120,7 @@ EOF
 }
 
 dockerImageScan() {
+    mkdir -p result
     # TODO check feasibility of mount/mountWithLayers
     IMAGE="${BUILDKITE_PLUGIN_WIZ_IMAGE_ADDRESS:-}"
     # make sure local docker has the image
@@ -132,7 +133,7 @@ dockerImageScan() {
         "${wiz_cli_container}" \
         docker scan --image "$IMAGE" \
         --policy-hits-only \
-        -o /scan/result,human,true ${args:+"${args[@]}"}
+        -o /scan/result/output,human,true ${args:+"${args[@]}"}
 
     exit_code="$?"
     image_name=$(echo "$IMAGE" | cut -d "/" -f 2)
@@ -140,10 +141,10 @@ dockerImageScan() {
     # buildkite-agent artifact upload result --log-level info
     case $exit_code in
     0)
-        buildAnnotation "docker" "$image_name" true "$PWD/result" | buildkite-agent annotate --append --style 'success' --context 'ctx-wiz-docker-success'
+        buildAnnotation "docker" "$image_name" true "result/output" | buildkite-agent annotate --append --style 'success' --context 'ctx-wiz-docker-success'
         ;;
     *)
-        buildAnnotation "docker" "$image_name" false "$PWD/result" | buildkite-agent annotate --append --context 'ctx-wiz-docker-warning' --style 'warning'
+        buildAnnotation "docker" "$image_name" false "result/output" | buildkite-agent annotate --append --context 'ctx-wiz-docker-warning' --style 'warning'
         ;;
     esac
     exit $exit_code


### PR DESCRIPTION
**Summary**
This PR aligns output for Docker scan with other scan types. Inconsistency was surfaced while testing https://github.com/buildkite-plugins/wiz-buildkite-plugin/pull/26.