### PR TITLE
SUP-3846: Add additional File Output Formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,10 +172,14 @@ Used when `scan-type` is `iac`.
 
 The path to image file, if the `scan-type` is `docker`.
 
-### `output-format` (Optional, string): `human | json | sarif`
+### `output-format` (Optional, string): `human | json | sarif | csv-zip`
 
 Scans output format.
 Defaults to: `human`
+
+### `additional-output` (Optional, string): `human | json | sarif | csv-zip`
+
+Generates an additional output file with the specified format.
 
 ### `parameter-files` (Optional, string)
 

--- a/README.md
+++ b/README.md
@@ -172,14 +172,15 @@ Used when `scan-type` is `iac`.
 
 The path to image file, if the `scan-type` is `docker`.
 
-### `output-format` (Optional, string): `human | json | sarif | csv-zip`
+### `scan-format` (Optional, string): `human | json | sarif`
 
 Scans output format.
 Defaults to: `human`
 
-### `additional-output` (Optional, string): `human | json | sarif | csv-zip`
+### `file-output-format` (Optional, string or array): `human | json | sarif | csv-zip`
 
 Generates an additional output file with the specified format.
+Defaults to: `human`
 
 ### `parameter-files` (Optional, string)
 
@@ -201,7 +202,7 @@ Defaults to: `false`
 To run the tests:
 
 ```shell
-docker-compose run --rm tests
+docker compose run --rm tests
 ```
 
 ## Contributing

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -8,6 +8,7 @@ FILE_PATH="${BUILDKITE_PLUGIN_WIZ_PATH:-}"
 PARAMETER_FILES="${BUILDKITE_PLUGIN_WIZ_PARAMETER_FILES:-}"
 IAC_TYPE="${BUILDKITE_PLUGIN_WIZ_IAC_TYPE:-}"
 OUTPUT_FORMAT="${BUILDKITE_PLUGIN_WIZ_OUTPUT_FORMAT:=human}"
+ADDITIONAL_OUTPUT="${BUILDKITE_PLUGIN_WIZ_ADDITIONAL_OUTPUT:-}"
 SHOW_SECRET_SNIPPETS="${BUILDKITE_PLUGIN_WIZ_SHOW_SECRET_SNIPPETS:=false}"
 
 if [[ -z "${SCAN_TYPE}" ]]; then
@@ -39,13 +40,23 @@ if [[ "${SHOW_SECRET_SNIPPETS}" == "true" ]]; then
     args+=("--show-secret-snippets")
 fi
 
-output_formats=("human" "json" "sarif")
+output_formats=("human" "json" "sarif" "csv-zip")
 if [[ ${output_formats[*]} =~ ${OUTPUT_FORMAT} ]]; then
     args+=("--format=${OUTPUT_FORMAT}")
 else
     echo "+++ 🚨 Invalid Output Format: ${OUTPUT_FORMAT}"
     echo "Valid Formats: ${output_formats[*]}"
     exit 1
+fi
+
+if [[ -n "${ADDITIONAL_OUTPUT}" ]]; then
+    if [[ ${output_formats[*]} =~ ${ADDITIONAL_OUTPUT} ]]; then
+        args+=("--output=/scan/result/output.${ADDITIONAL_OUTPUT},${ADDITIONAL_OUTPUT}")
+    else
+        echo "+++ 🚨 Invalid Additional Output Format: ${ADDITIONAL_OUTPUT}"
+        echo "Valid Formats: ${output_formats[*]}"
+        exit 1
+    fi
 fi
 
 ## IAC Scanning Parameters

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -7,8 +7,8 @@ SCAN_TYPE="${BUILDKITE_PLUGIN_WIZ_SCAN_TYPE:-}"
 FILE_PATH="${BUILDKITE_PLUGIN_WIZ_PATH:-}"
 PARAMETER_FILES="${BUILDKITE_PLUGIN_WIZ_PARAMETER_FILES:-}"
 IAC_TYPE="${BUILDKITE_PLUGIN_WIZ_IAC_TYPE:-}"
-OUTPUT_FORMAT="${BUILDKITE_PLUGIN_WIZ_OUTPUT_FORMAT:=human}"
-ADDITIONAL_OUTPUT="${BUILDKITE_PLUGIN_WIZ_ADDITIONAL_OUTPUT:-}"
+SCAN_FORMAT="${BUILDKITE_PLUGIN_WIZ_SCAN_FORMAT:=human}"
+FILE_OUTPUT_FORMAT="${BUILDKITE_PLUGIN_WIZ_FILE_OUTPUT_FORMAT:=human}"
 SHOW_SECRET_SNIPPETS="${BUILDKITE_PLUGIN_WIZ_SHOW_SECRET_SNIPPETS:=false}"
 
 if [[ -z "${SCAN_TYPE}" ]]; then
@@ -40,23 +40,26 @@ if [[ "${SHOW_SECRET_SNIPPETS}" == "true" ]]; then
     args+=("--show-secret-snippets")
 fi
 
-output_formats=("human" "json" "sarif" "csv-zip")
-if [[ ${output_formats[*]} =~ ${OUTPUT_FORMAT} ]]; then
-    args+=("--format=${OUTPUT_FORMAT}")
+scan_formats=("human" "json" "sarif")
+if [[ ${scan_formats[*]} =~ ${SCAN_FORMAT} ]]; then
+    args+=("--format=${SCAN_FORMAT}")
 else
-    echo "+++ 🚨 Invalid Output Format: ${OUTPUT_FORMAT}"
-    echo "Valid Formats: ${output_formats[*]}"
+    echo "+++ 🚨 Invalid Scan Format: ${SCAN_FORMAT}"
+    echo "Valid Formats: ${scan_formats[*]}"
     exit 1
 fi
 
-if [[ -n "${ADDITIONAL_OUTPUT}" ]]; then
-    if [[ ${output_formats[*]} =~ ${ADDITIONAL_OUTPUT} ]]; then
-        args+=("--output=/scan/result/output.${ADDITIONAL_OUTPUT},${ADDITIONAL_OUTPUT}")
-    else
-        echo "+++ 🚨 Invalid Additional Output Format: ${ADDITIONAL_OUTPUT}"
-        echo "Valid Formats: ${output_formats[*]}"
-        exit 1
-    fi
+file_output_formats=("human" "json" "sarif" "csv-zip")
+if [[ -n "${FILE_OUTPUT_FORMAT}" ]]; then
+    for format in ${FILE_OUTPUT_FORMAT}; do
+        if [[ ${file_output_formats[*]} =~ ${format} ]]; then
+            args+=("--output=/scan/result/output,${format}")
+        else
+            echo "+++ 🚨 Invalid File Output Format: ${format}"
+            echo "Valid Formats: ${file_output_formats[*]}"
+            exit 1
+        fi
+    done
 fi
 
 ## IAC Scanning Parameters
@@ -143,7 +146,7 @@ dockerImageScan() {
         "${wiz_cli_container}" \
         docker scan --image "$IMAGE" \
         --policy-hits-only \
-        -o /scan/result,human,true ${args:+"${args[@]}"}
+        ${args:+"${args[@]}"}
 
     exit_code="$?"
     image_name=$(echo "$IMAGE" | cut -d "/" -f 2)
@@ -168,7 +171,6 @@ iacScan() {
         --mount type=bind,src="$PWD",dst=/scan \
         "${wiz_cli_container}" \
         iac scan \
-        -o /scan/result/output,human \
         --name "$BUILDKITE_JOB_ID" \
         --path "/scan/$FILE_PATH" ${args:+"${args[@]}"}
 
@@ -196,7 +198,6 @@ dirScan() {
         --mount type=bind,src="$PWD",dst=/scan \
         "${wiz_cli_container}" \
         dir scan \
-        -o /scan/result/output,human \
         --name "$BUILDKITE_JOB_ID" \
         --path "/scan/$FILE_PATH" ${args:+"${args[@]}"}
 

--- a/plugin.yml
+++ b/plugin.yml
@@ -10,21 +10,22 @@ configuration:
       type: string
     image-address:
       type: string
-    output-format:
+    scan-format:
       type: string
+      enum:
+        - human
+        - json
+        - sarif
+      default: human
+    file-output-format:
+      type: [string, array]
       enum:
         - human
         - json
         - sarif
         - csv-zip
       default: human
-    additional-output:
-      type: string
-      enum:
-        - human
-        - json
-        - sarif
-        - csv-zip
+      minimum: 1
     parameter-files:
       type: string
     path:
@@ -34,7 +35,7 @@ configuration:
       enum:
         - dir
         - docker
-        - iac  
+        - iac
     show-secret-snippets:
       type: boolean
       default: false
@@ -42,10 +43,10 @@ configuration:
       type: string
       enum:
         - Ansible
-        - AzureResourceManager 
-        - Cloudformation 
-        - Dockerfile 
-        - GoogleCloudDeploymentManager 
+        - AzureResourceManager
+        - Cloudformation
+        - Dockerfile
+        - GoogleCloudDeploymentManager
         - Kubernetes
         - Terraform
   required:

--- a/plugin.yml
+++ b/plugin.yml
@@ -16,7 +16,15 @@ configuration:
         - human
         - json
         - sarif
+        - csv-zip
       default: human
+    additional-output:
+      type: string
+      enum:
+        - human
+        - json
+        - sarif
+        - csv-zip
     parameter-files:
       type: string
     path:

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -113,3 +113,13 @@ setup() {
   
   assert_failure
 }
+
+@test "Invalid Additional Output Format" {
+  export WIZ_API_SECRET="secret"
+  export BUILDKITE_PLUGIN_WIZ_ADDITIONAL_OUTPUT="wrong-format"
+
+  run "$PWD/hooks/post-command"
+  assert_output --partial "+++ 🚨 Invalid Additional Output Format: $BUILDKITE_PLUGIN_WIZ_ADDITIONAL_OUTPUT"
+
+  assert_failure
+}

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -104,22 +104,22 @@ setup() {
   assert_failure
 }
 
-@test "Invalid Output Format" {
+@test "Invalid Scan Format" {
   export WIZ_API_SECRET="secret"
-  export BUILDKITE_PLUGIN_WIZ_OUTPUT_FORMAT="wrong-format"
+  export BUILDKITE_PLUGIN_WIZ_SCAN_FORMAT="wrong-format"
 
   run "$PWD/hooks/post-command"
-  assert_output --partial "+++ 🚨 Invalid Output Format: $BUILDKITE_PLUGIN_WIZ_OUTPUT_FORMAT"
+  assert_output --partial "+++ 🚨 Invalid Scan Format: $BUILDKITE_PLUGIN_WIZ_SCAN_FORMAT"
   
   assert_failure
 }
 
-@test "Invalid Additional Output Format" {
+@test "Invalid File Output Format" {
   export WIZ_API_SECRET="secret"
-  export BUILDKITE_PLUGIN_WIZ_ADDITIONAL_OUTPUT="wrong-format"
+  export BUILDKITE_PLUGIN_WIZ_FILE_OUTPUT_FORMAT="wrong-format"
 
   run "$PWD/hooks/post-command"
-  assert_output --partial "+++ 🚨 Invalid Additional Output Format: $BUILDKITE_PLUGIN_WIZ_ADDITIONAL_OUTPUT"
+  assert_output --partial "+++ 🚨 Invalid File Output Format: $BUILDKITE_PLUGIN_WIZ_FILE_OUTPUT_FORMAT"
 
   assert_failure
 }


### PR DESCRIPTION
based on comments made here: https://github.com/buildkite-plugins/wiz-buildkite-plugin/pull/26#issuecomment-2948702357

There was an oversight in how the original Scan and File formats were setup and incorretly. So correcting this and adding the additional file formats from https://github.com/buildkite-plugins/wiz-buildkite-plugin/pull/26