### PR TITLE
Bugfix: Redirect stderr logs

### DIFF
--- a/lib/plugin.bash
+++ b/lib/plugin.bash
@@ -22,8 +22,8 @@ function build_wiz_cli_args() {
     if [[ ${scan_formats[*]} =~ ${SCAN_FORMAT} ]]; then
         args+=("--format=${SCAN_FORMAT}")
     else
-        echo "+++ 🚨 Invalid Scan Format: ${SCAN_FORMAT}"
-        echo "Valid Formats: ${scan_formats[*]}"
+        echo "+++ 🚨 Invalid Scan Format: ${SCAN_FORMAT}" >&2
+        echo "Valid Formats: ${scan_formats[*]}" >&2
         exit 1
     fi
 
@@ -56,8 +56,8 @@ function build_wiz_cli_args() {
             if in_array "$format" "${valid_file_formats[@]}"; then
                 args+=("--output=/scan/result/output-${format},${format}")
             else
-                echo "+++ 🚨 Invalid File Output Format: ${format}"
-                echo "Valid Formats: ${valid_file_formats[*]}"
+                echo "+++ 🚨 Invalid File Output Format: ${format}" >&2
+                echo "Valid Formats: ${valid_file_formats[*]}" >&2
                 exit 1
             fi
         done
@@ -107,7 +107,7 @@ function validate_wiz_client_credentials() {
     [ -z "${WIZ_CLIENT_SECRET:-}" ] && missing_vars+=("WIZ_CLIENT_SECRET")
 
     if [ ${#missing_vars[@]} -gt 0 ]; then
-        echo "+++ 🚨 The following required environment variables are not set: ${missing_vars[*]}"
+        echo "+++ 🚨 The following required environment variables are not set: ${missing_vars[*]}" >&2
         exit 1
     fi
 }
@@ -120,12 +120,12 @@ function get_wiz_auth_file() {
     local wiz_dir="${2:-}"
 
     if [ -z "${wiz_container_image}" ]; then
-        echo "+++ 🚨 Wiz CLI container image not specified"
+        echo "+++ 🚨 Wiz CLI container image not specified" >&2
         exit 1
     fi
         
     if [ -z "${wiz_dir}" ]; then
-        echo "+++ 🚨 Wiz directory not specified"
+        echo "+++ 🚨 Wiz directory not specified" >&2
         return 1
     fi
 
@@ -143,7 +143,7 @@ function get_wiz_auth_file() {
 
     # check that wiz-auth work expected, and a file in WIZ_DIR is created
     if [ -z "$(ls -A "${wiz_dir}")" ]; then
-        echo "+++ 🚨 Wiz authentication failed, please confirm the credentials are set for WIZ_CLIENT_ID and WIZ_CLIENT_SECRET"
+        echo "+++ 🚨 Wiz authentication failed, please confirm the credentials are set for WIZ_CLIENT_ID and WIZ_CLIENT_SECRET" >&2
         exit 1
     else
         echo "Authenticated successfully"

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -146,3 +146,42 @@ teardown() {
   unstub docker
   unstub buildkite-agent
 }
+
+@test "Directory Scan with Invalid Scan Format" {
+  export BUILDKITE_PLUGIN_WIZ_SCAN_TYPE="dir"
+  export BUILDKITE_PLUGIN_WIZ_PATH="dir/to/scan"
+  export BUILDKITE_PLUGIN_WIZ_SCAN_FORMAT="invalid"
+
+  run "$PWD/hooks/post-command"
+  
+  assert_failure
+
+  assert_output --partial "+++ 🚨 Invalid Scan Format: invalid"
+  assert_output --partial "Valid Formats: human json sarif"
+}
+
+@test "Directory Scan with Invalid Output Format" {
+  export BUILDKITE_PLUGIN_WIZ_SCAN_TYPE="dir"
+  export BUILDKITE_PLUGIN_WIZ_PATH="dir/to/scan"
+  export BUILDKITE_PLUGIN_WIZ_FILE_OUTPUT_FORMAT="invalid"
+
+  run "$PWD/hooks/post-command"
+  
+  assert_failure
+
+  assert_output --partial "+++ 🚨 Invalid File Output Format: invalid"
+  assert_output --partial "Valid Formats: human json sarif csv-zip"
+}
+
+@test "Directory Scan with unset Wiz Credentials" {
+  export BUILDKITE_PLUGIN_WIZ_SCAN_TYPE="dir"
+  export BUILDKITE_PLUGIN_WIZ_PATH="dir/to/scan"
+  unset WIZ_CLIENT_ID
+  unset WIZ_CLIENT_SECRET
+
+  run "$PWD/hooks/post-command"
+  
+  assert_failure
+
+  assert_output --partial "+++ 🚨 The following required environment variables are not set: WIZ_CLIENT_ID WIZ_CLIENT_SECRET"
+}


### PR DESCRIPTION
Due to use of functions and capturing of them for ouput, some of the error messages were not being surfaced in Jobs Logs.
So redirecting these messages to stderr and adding tests to confirm surfacing.
