### PR TITLE
Update wizcli to v1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Wiz CLI binary (local development artifact)
+wizcli
+
 .vscode/*
 !.vscode/settings.json
 !.vscode/tasks.json

--- a/README.md
+++ b/README.md
@@ -26,11 +26,15 @@ v3 upgrades the underlying Wiz CLI from v0.x to v1.x. WizCLI v0.x reached End of
 Breaking changes:
 
 - The `show-secret-snippets` option has been removed (not supported by WizCLI v1 scan commands).
-- Authentication is now handled inline by scan commands via `WIZ_CLIENT_ID` and `WIZ_CLIENT_SECRET` environment variables, rather than a separate auth step.
-- Three new `iac-type` values are supported: `Bicep`, `GitHubActions`, and `Pulumi`.
-- A new `disable-sensitive-data-scan` option lets you opt out of the sensitive data scanner (enabled by default in WizCLI v1).
+- Sensitive data scanning (PII, PCI, PHI) is now enabled by default. Use the `disable-sensitive-data-scan` option to opt out.
 
 No changes are required to your pipeline YAML unless you were using `show-secret-snippets`.
+
+New in v3:
+
+- Three new `iac-type` values: `Bicep`, `GitHubActions`, and `Pulumi`.
+- The `iac-type` and `parameter-files` options now apply to `dir` scans in addition to `iac` scans.
+- The WizCLI container image is now pulled from `public-registry.wiz.io/wiz-app/wizcli`. If your agents use firewall or registry allowlists, update them to permit access to this registry.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Breaking changes:
 - The `show-secret-snippets` option has been removed (not supported by WizCLI v1 scan commands).
 - Authentication is now handled inline by scan commands via `WIZ_CLIENT_ID` and `WIZ_CLIENT_SECRET` environment variables, rather than a separate auth step.
 - Three new `iac-type` values are supported: `Bicep`, `GitHubActions`, and `Pulumi`.
-- A new `sensitive-data` option enables sensitive data detection for Docker image scans.
+- A new `disable-sensitive-data-scan` option lets you opt out of the sensitive data scanner (enabled by default in WizCLI v1).
 
 No changes are required to your pipeline YAML unless you were using `show-secret-snippets`.
 
@@ -190,9 +190,9 @@ The file or directory to scan.
 Used when `scan-type` is `dir` or `iac`.
 Defaults to: repository root (`.`)
 
-### `sensitive-data` (Optional, bool)
+### `disable-sensitive-data-scan` (Optional, bool)
 
-Enable sensitive data detection (PII, PCI, PHI) for Docker image scans.
+Disable the sensitive data scanner (PII, PCI, PHI detection). WizCLI v1 enables this scanner by default.
 Defaults to: `false`
 
 ## Developing

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ steps:
   - command: ls
     plugins:
       - docker-compose#v5.12.1:
+          # Mount cdk.out so it's available for the wiz scan
           volumes:
             - './infrastructure/cdk.out:/app/infrastructure/cdk.out'
       - wiz#v3.0.0:
@@ -166,7 +167,8 @@ Used when `scan-type` is `iac` or `dir`.
 
 ### `image-address` (Optional, string)
 
-The container registry address of the image to scan (e.g., `myregistry.io/image:tag`). Required when `scan-type` is `docker`.
+The container registry address of the image to scan (e.g., `myregistry.io/image:tag`).
+Used when `scan-type` is `docker`.
 
 ### `scan-format` (Optional, string): `human | json | sarif`
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,19 @@ And the following environment variables exported in the job (e.g. via an Agent h
 
 Check out [Buildkite's documentation](https://buildkite.com/docs/pipelines/security/secrets/managing) for more information on how to manage secrets in Buildkite.
 
+## Migrating from v2 to v3
+
+v3 upgrades the underlying Wiz CLI from v0.x to v1.x. WizCLI v0.x reached End of Support on April 15, 2026.
+
+Breaking changes:
+
+- The `show-secret-snippets` option has been removed (not supported by WizCLI v1 scan commands).
+- Authentication is now handled inline by scan commands via `WIZ_CLIENT_ID` and `WIZ_CLIENT_SECRET` environment variables, rather than a separate auth step.
+- Three new `iac-type` values are supported: `Bicep`, `GitHubActions`, and `Pulumi`.
+- A new `sensitive-data` option enables sensitive data detection for Docker image scans.
+
+No changes are required to your pipeline YAML unless you were using `show-secret-snippets`.
+
 ## Examples
 
 ### Docker Scanning
@@ -29,18 +42,9 @@ Add the following to your `pipeline.yml`, the plugin will pull the image, scan i
 steps:
   - command: ls
     plugins:
-      - wiz#v2.0.0:
+      - wiz#v3.0.0:
           scan-type: 'docker'
           image-address: "<image-address-to-pull-and-scan>"
-```
-
-If you are using the [AWS Assume Role Plugin](https://github.com/cultureamp/aws-assume-role-buildkite-plugin), you might have trouble getting your secret key from `aws secretsmanager` if the role you assumed doesn't have the necessary access rights. To restore your role, you can use the [AWS Restore Role Buildkite Plugin](https://github.com/franklin-ross/aws-restore-role-buildkite-plugin) before the wiz plugin.
-
-```yml
-  plugins:
-      - franklin-ross/aws-restore-role#HEAD
-      - wiz#v2.0.0:
-        scan-type: 'docker'
 ```
 
 ### AWS `cdk diff` Scanning
@@ -51,11 +55,10 @@ To avoid adding build time overhead, you can add IaC scanning to your `cdk diff`
 steps:
   - command: ls
     plugins:
-      - docker-compose#v4.16.0:
-        # to get the output of CDK diff, mount the volume in cdk diff stage
-        - volumes:
-          - './infrastructure/cdk.out:/app/infrastructure/cdk.out'
-      - wiz#v2.0.0:
+      - docker-compose#v5.12.1:
+          volumes:
+            - './infrastructure/cdk.out:/app/infrastructure/cdk.out'
+      - wiz#v3.0.0:
           scan-type: 'iac'
           path: "infrastructure/cdk.out"
 ```
@@ -69,7 +72,7 @@ steps:
   - label: "Scan CloudFormation template file"
     command: ls
     plugins:
-      - wiz#v2.0.0:
+      - wiz#v3.0.0:
           scan-type: 'iac'
           iac-type: 'Cloudformation'
           path: 'cf-template.yaml'
@@ -87,7 +90,7 @@ steps:
   - label: "Scan Terraform File"
     command: ls *.tf
     plugins:
-      - wiz#v2.0.0:
+      - wiz#v3.0.0:
           scan-type: 'iac'
           iac-type: 'Terraform'
           path: 'main.tf'
@@ -102,7 +105,7 @@ steps:
   - label: "Scan Terraform Files in Directory"
     command: ls my-terraform-dir/*.tf
     plugins:
-      - wiz#v2.0.0:
+      - wiz#v3.0.0:
           scan-type: 'iac'
           iac-type: 'Terraform'
           path: 'my-terraform-dir'
@@ -117,7 +120,7 @@ steps:
   - label: "Scan Terraform Plan"
     command: terraform plan -out plan.tfplan && terraform show -json plan.tfplan | jq -er . > plan.tfplanjson
     plugins:
-      - wiz#v2.0.0:
+      - wiz#v3.0.0:
           scan-type: 'iac'
           iac-type: 'Terraform'
           path: 'plan.tfplanjson'
@@ -132,9 +135,9 @@ steps:
   - label: "Scan Directory"
     command: ls .
     plugins:
-      - wiz#v2.0.0:
+      - wiz#v3.0.0:
           scan-type: 'dir'
-          path: 'main.tf'
+          path: 'src'
 ```
 
 By default, `path` parameter will be the root of your repository, and scan all files in the local directory.
@@ -145,25 +148,25 @@ steps:
   - label: "Scan Files in different Directory"
     command: ls my-dir
     plugins:
-      - wiz#v2.0.0:
+      - wiz#v3.0.0:
           scan-type: 'dir'
           path: 'my-dir'
 ```
 
 ## Configuration
 
-### `scan-type` (Required, string) : `dir | docker | iac'
+### `scan-type` (Required, string): `dir | docker | iac`
 
 The type of resource to be scanned.
 
-### `iac-type` (Optional, string): `Ansible | AzureResourceManager | Cloudformation | Dockerfile | GoogleCloudDeploymentManager | Kubernetes | Terraform`
+### `iac-type` (Optional, string): `Ansible | AzureResourceManager | Bicep | Cloudformation | Dockerfile | GitHubActions | GoogleCloudDeploymentManager | Kubernetes | Pulumi | Terraform`
 
 Narrow down the scan to specific type.
-Used when `scan-type` is `iac`.
+Used when `scan-type` is `iac` or `dir`.
 
 ### `image-address` (Optional, string)
 
-The path to image file, if the `scan-type` is `docker`.
+The container registry address of the image to scan (e.g., `myregistry.io/image:tag`). Required when `scan-type` is `docker`.
 
 ### `scan-format` (Optional, string): `human | json | sarif`
 
@@ -177,16 +180,17 @@ Generates an additional output file with the specified format.
 ### `parameter-files` (Optional, string)
 
 Comma separated list of globs of external parameter files to include while scanning e.g., `variables.tf`
-Used when `scan-type` is `iac`.
+Used when `scan-type` is `iac` or `dir`.
 
 ### `path` (Optional, string)
 
-The file or directory to scan, defaults to the root directory of repository.
+The file or directory to scan.
 Used when `scan-type` is `dir` or `iac`.
+Defaults to: repository root (`.`)
 
-### `show-secret-snippets` (Optional, bool)
+### `sensitive-data` (Optional, bool)
 
-Enable snippets in secrets.
+Enable sensitive data detection (PII, PCI, PHI) for Docker image scans.
 Defaults to: `false`
 
 ## Developing

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -10,7 +10,6 @@ DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 # shellcheck source=lib/shared.bash
 . "$DIR/../lib/shared.bash"
 
-WIZ_DIR="$HOME/.wiz"
 SCAN_TYPE="${BUILDKITE_PLUGIN_WIZ_SCAN_TYPE:-}"
 FILE_PATH="${BUILDKITE_PLUGIN_WIZ_PATH:-}"
 
@@ -24,20 +23,21 @@ if [[ "${SCAN_TYPE}" == "docker" && -z "${BUILDKITE_PLUGIN_WIZ_IMAGE_ADDRESS:-}"
     exit 1
 fi
 
+validate_wiz_client_credentials
+
 declare -a cli_args
 # shellcheck disable=SC2207
 cli_args=($(build_wiz_cli_args "${SCAN_TYPE}"))
 wiz_cli_container_image=$(detect_wiz_cli_container)
-get_wiz_auth_file "$wiz_cli_container_image" "$WIZ_DIR"
 
 case "${SCAN_TYPE}" in
 iac)
-    iac_scan "$wiz_cli_container_image" "$WIZ_DIR" "${FILE_PATH}" "${cli_args[@]}"
+    iac_scan "$wiz_cli_container_image" "${FILE_PATH}" "${cli_args[@]}"
     ;;
 docker)
-    docker_image_scan "$wiz_cli_container_image" "$WIZ_DIR" "${BUILDKITE_PLUGIN_WIZ_IMAGE_ADDRESS}" "${cli_args[@]}"
+    docker_image_scan "$wiz_cli_container_image" "${BUILDKITE_PLUGIN_WIZ_IMAGE_ADDRESS}" "${cli_args[@]}"
     ;;
 dir)
-    dir_scan "$wiz_cli_container_image" "$WIZ_DIR" "${FILE_PATH}" "${cli_args[@]}"
+    dir_scan "$wiz_cli_container_image" "${FILE_PATH}" "${cli_args[@]}"
     ;;
 esac

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -11,7 +11,7 @@ DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)"
 . "$DIR/../lib/shared.bash"
 
 SCAN_TYPE="${BUILDKITE_PLUGIN_WIZ_SCAN_TYPE:-}"
-FILE_PATH="${BUILDKITE_PLUGIN_WIZ_PATH:-}"
+FILE_PATH="${BUILDKITE_PLUGIN_WIZ_PATH:-.}"
 
 if [[ -z "${SCAN_TYPE}" ]]; then
     echo "+++ 🚨 Missing scan type. Possible values: 'iac', 'docker', 'dir'"

--- a/lib/plugin.bash
+++ b/lib/plugin.bash
@@ -97,7 +97,7 @@ function validate_wiz_client_credentials() {
 # $3 - scan pass/fail
 # $4 - scan result file
 function build_annotation() {
-    annotation_file=${RANDOM:0:2}-annotation.md
+    local annotation_file="${RANDOM:0:2}-annotation.md"
     local scan_label
     case "$1" in
         docker) scan_label="Wiz Docker Image Scan" ;;
@@ -105,8 +105,9 @@ function build_annotation() {
         dir)    scan_label="Wiz Directory Scan" ;;
         *)      scan_label="Wiz Scan" ;;
     esac
+    local pass_or_fail
     pass_or_fail=$(if [ "$3" = "true" ]; then echo 'meets'; else echo 'does not meet'; fi)
-    summary="${scan_label} for ${2} ${pass_or_fail} policy requirements"
+    local summary="${scan_label} for ${2} ${pass_or_fail} policy requirements"
     cat <<EOF >>./"${annotation_file}"
 <details>
 <summary>$summary.</summary>

--- a/lib/plugin.bash
+++ b/lib/plugin.bash
@@ -145,7 +145,6 @@ function docker_image_scan() {
         --mount type=bind,src=/var/run/docker.sock,dst=/var/run/docker.sock,readonly \
         "${wiz_cli_container_image}" \
         scan container-image "$image" \
-        --by-policy-hits="BLOCK" \
         "${cli_args[@]}" || exit_code=$?
 
     local image_name

--- a/lib/plugin.bash
+++ b/lib/plugin.bash
@@ -148,7 +148,7 @@ function docker_image_scan() {
         "${cli_args[@]}" || exit_code=$?
 
     local image_name
-    image_name="$(echo "$image" | cut -d "/" -f 2)"
+    image_name="${image##*/}"
 
     if [[ $exit_code -eq 0 ]]; then
         build_annotation "docker" "$image_name" true "result/output" | buildkite-agent annotate --append --context 'ctx-wiz-docker-success' --style 'success'

--- a/lib/plugin.bash
+++ b/lib/plugin.bash
@@ -10,11 +10,11 @@ function build_wiz_cli_args() {
     PARAMETER_FILES="${BUILDKITE_PLUGIN_WIZ_PARAMETER_FILES:-}"
     IAC_TYPE="${BUILDKITE_PLUGIN_WIZ_IAC_TYPE:-}"
     SCAN_FORMAT="${BUILDKITE_PLUGIN_WIZ_SCAN_FORMAT:=human}"
-    SENSITIVE_DATA="${BUILDKITE_PLUGIN_WIZ_SENSITIVE_DATA:=false}"
+    DISABLE_SENSITIVE_DATA_SCAN="${BUILDKITE_PLUGIN_WIZ_DISABLE_SENSITIVE_DATA_SCAN:=false}"
     local -a args=()
 
-    if [[ "${scan_type}" == "docker" && "${SENSITIVE_DATA}" == "true" ]]; then
-        args+=("--sensitive-data")
+    if [[ "${DISABLE_SENSITIVE_DATA_SCAN}" == "true" ]]; then
+        args+=("--disabled-scanners=SensitiveData")
     fi
 
     local scan_formats=("human" "json" "sarif")

--- a/lib/plugin.bash
+++ b/lib/plugin.bash
@@ -7,21 +7,21 @@ set -euo pipefail
 function build_wiz_cli_args() {
     local scan_type="${1}"
 
-    PARAMETER_FILES="${BUILDKITE_PLUGIN_WIZ_PARAMETER_FILES:-}"
-    IAC_TYPE="${BUILDKITE_PLUGIN_WIZ_IAC_TYPE:-}"
-    SCAN_FORMAT="${BUILDKITE_PLUGIN_WIZ_SCAN_FORMAT:=human}"
-    DISABLE_SENSITIVE_DATA_SCAN="${BUILDKITE_PLUGIN_WIZ_DISABLE_SENSITIVE_DATA_SCAN:=false}"
+    local parameter_files="${BUILDKITE_PLUGIN_WIZ_PARAMETER_FILES:-}"
+    local iac_type="${BUILDKITE_PLUGIN_WIZ_IAC_TYPE:-}"
+    local scan_format="${BUILDKITE_PLUGIN_WIZ_SCAN_FORMAT:-human}"
+    local disable_sensitive_data_scan="${BUILDKITE_PLUGIN_WIZ_DISABLE_SENSITIVE_DATA_SCAN:-false}"
     local -a args=()
 
-    if [[ "${DISABLE_SENSITIVE_DATA_SCAN}" == "true" ]]; then
+    if [[ "${disable_sensitive_data_scan}" == "true" ]]; then
         args+=("--disabled-scanners=SensitiveData")
     fi
 
     local scan_formats=("human" "json" "sarif")
-    if [[ ${scan_formats[*]} =~ ${SCAN_FORMAT} ]]; then
-        args+=("--stdout=${SCAN_FORMAT}")
+    if [[ ${scan_formats[*]} =~ ${scan_format} ]]; then
+        args+=("--stdout=${scan_format}")
     else
-        echo "+++ 🚨 Invalid Scan Format: ${SCAN_FORMAT}" >&2
+        echo "+++ 🚨 Invalid Scan Format: ${scan_format}" >&2
         echo "Valid Formats: ${scan_formats[*]}" >&2
         exit 1
     fi
@@ -61,12 +61,12 @@ function build_wiz_cli_args() {
 
     # IaC-specific parameters apply to both iac and dir scan types
     if [[ "${scan_type}" == "iac" || "${scan_type}" == "dir" ]]; then
-        if [[ -n "${IAC_TYPE}" ]]; then
-            args+=("--types=${IAC_TYPE}")
+        if [[ -n "${iac_type}" ]]; then
+            args+=("--types=${iac_type}")
         fi
 
-        if [[ -n "${PARAMETER_FILES}" ]]; then
-            args+=("--parameter-files=${PARAMETER_FILES}")
+        if [[ -n "${parameter_files}" ]]; then
+            args+=("--parameter-files=${parameter_files}")
         fi
     fi
 

--- a/lib/plugin.bash
+++ b/lib/plugin.bash
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-# Used to generate the Wiz CLI arguments, including using the scan type for specific arguments
+# Build CLI arguments for v1 scan commands.
 # $1 - Scan Type
 function build_wiz_cli_args() {
     local scan_type="${1}"
@@ -10,17 +10,16 @@ function build_wiz_cli_args() {
     PARAMETER_FILES="${BUILDKITE_PLUGIN_WIZ_PARAMETER_FILES:-}"
     IAC_TYPE="${BUILDKITE_PLUGIN_WIZ_IAC_TYPE:-}"
     SCAN_FORMAT="${BUILDKITE_PLUGIN_WIZ_SCAN_FORMAT:=human}"
-    SHOW_SECRET_SNIPPETS="${BUILDKITE_PLUGIN_WIZ_SHOW_SECRET_SNIPPETS:=false}"
+    SENSITIVE_DATA="${BUILDKITE_PLUGIN_WIZ_SENSITIVE_DATA:=false}"
     local -a args=()
 
-    # Global Parameters
-    if [[ "${SHOW_SECRET_SNIPPETS}" == "true" ]]; then
-        args+=("--show-secret-snippets")
+    if [[ "${scan_type}" == "docker" && "${SENSITIVE_DATA}" == "true" ]]; then
+        args+=("--sensitive-data")
     fi
 
     local scan_formats=("human" "json" "sarif")
     if [[ ${scan_formats[*]} =~ ${SCAN_FORMAT} ]]; then
-        args+=("--format=${SCAN_FORMAT}")
+        args+=("--stdout=${SCAN_FORMAT}")
     else
         echo "+++ 🚨 Invalid Scan Format: ${SCAN_FORMAT}" >&2
         echo "Valid Formats: ${scan_formats[*]}" >&2
@@ -30,8 +29,8 @@ function build_wiz_cli_args() {
     # Define valid formats
     local valid_file_formats=("human" "json" "sarif" "csv-zip")
 
-    # Default file output which is used for build annotation
-    args+=("--output=/scan/result/output,human")
+    # Default file output used for build annotation
+    args+=("--human-output-file=/scan/result/output")
 
     # Declare result array
     declare -a result
@@ -40,21 +39,18 @@ function build_wiz_cli_args() {
     if plugin_read_list_into_result "BUILDKITE_PLUGIN_WIZ_FILE_OUTPUT_FORMAT"; then
         declare -A seen_formats
         for format in "${result[@]}"; do
-            # Multiple output files with the same format are supported
-            # but would need to rework this loop to handle and validate i.e., specifying file names, etc.,
-            #  -o, --output file-outputs             Output to file, can be passed multiple times to output to multiple files with possibly different formats.
-            #                                        Must be specified in the following format: file-path[,file-format[,policy-hits-only[,group-by[,include-audit-policy-hits]]]]
-            #                                        Options for file-format: [csv-zip, human, json, sarif], policy-hits-only: [true, false], group-by: [default, layer, resource], include-audit-policy-hits: [true, false]
-            # Check for duplicates
             if [[ -n "${seen_formats[$format]:-}" ]]; then
                 echo "+++ ⚠️  Duplicate file output format ignored: ${format}"
                 continue
             fi
             seen_formats["$format"]=1
 
-            # Check for invalid formats
             if in_array "$format" "${valid_file_formats[@]}"; then
-                args+=("--output=/scan/result/output-${format},${format}")
+                local flag_prefix="${format}"
+                if [[ "${format}" == "csv-zip" ]]; then
+                    flag_prefix="csv"
+                fi
+                args+=("--${flag_prefix}-output-file=/scan/result/output-${format}")
             else
                 echo "+++ 🚨 Invalid File Output Format: ${format}" >&2
                 echo "Valid Formats: ${valid_file_formats[*]}" >&2
@@ -63,9 +59,8 @@ function build_wiz_cli_args() {
         done
     fi
 
-    # IAC Scanning Parameters
-    if [[ "${scan_type}" == "iac" ]]; then
-
+    # IaC-specific parameters apply to both iac and dir scan types
+    if [[ "${scan_type}" == "iac" || "${scan_type}" == "dir" ]]; then
         if [[ -n "${IAC_TYPE}" ]]; then
             args+=("--types=${IAC_TYPE}")
         fi
@@ -78,26 +73,10 @@ function build_wiz_cli_args() {
     echo "${args[*]}"
 }
 
-# Determine the machine architecture to select the appropriate container image tag.
-# Available images: `latest`, `latest-amd64`, and `latest-arm64`.
-# For x86_64 and arm64/aarch64, use the corresponding tag; for unknown architectures, fallback to the default `latest` tag.
+# Return the v1 Wiz CLI container image reference.
+# The v1 image is multi-arch, so no architecture-specific tags are needed.
 function detect_wiz_cli_container() {
-    local architecture
-    architecture=$(uname -m)
-    local container_image_tag="latest"
-
-    case $architecture in
-    x86_64)
-        container_image_tag+="-amd64"
-        ;;
-    arm64 | aarch64)
-        container_image_tag+="-arm64"
-        ;;
-    *) ;;
-    esac
-
-    local wiz_cli_container_repository="wiziocli.azurecr.io/wizcli"
-    echo "${wiz_cli_container_repository}:${container_image_tag}"
+    echo "public-registry.wiz.io/wiz-app/wizcli:1"
 }
 
 function validate_wiz_client_credentials() {
@@ -112,55 +91,22 @@ function validate_wiz_client_credentials() {
     fi
 }
 
-# Use WIZ_CLIENT_ID and WIZ_CLIENT_SECRET environment variables to authenticate to Wiz and get auth file
-# $1 - Wiz CLI Container Image 
-# $2 - Directory to store auth file
-function get_wiz_auth_file() {
-    local wiz_container_image="${1:-}"
-    local wiz_dir="${2:-}"
-
-    if [ -z "${wiz_container_image}" ]; then
-        echo "+++ 🚨 Wiz CLI container image not specified" >&2
-        exit 1
-    fi
-        
-    if [ -z "${wiz_dir}" ]; then
-        echo "+++ 🚨 Wiz directory not specified" >&2
-        exit 1
-    fi
-
-    echo "Setting up and authenticating wiz"
-    validate_wiz_client_credentials
-    mkdir -p "$wiz_dir"
-
-    docker run \
-        --rm \
-        --mount type=bind,src="${wiz_dir}",dst=/cli \
-        -e WIZ_CLIENT_ID \
-        -e WIZ_CLIENT_SECRET \
-        "${wiz_container_image}" \
-        auth
-
-    # check that wiz-auth work expected, and a file in WIZ_DIR is created
-    if [ -z "$(ls -A "${wiz_dir}")" ]; then
-        echo "+++ 🚨 Wiz authentication failed, please confirm the credentials are set for WIZ_CLIENT_ID and WIZ_CLIENT_SECRET" >&2
-        exit 1
-    else
-        echo "Authenticated successfully"
-    fi
-}
-
-# Create a Buildkite Annotation from a scan results
+# Create a Buildkite Annotation from scan results.
 # $1 - scan type
 # $2 - scan name
 # $3 - scan pass/fail
 # $4 - scan result file
 function build_annotation() {
     annotation_file=${RANDOM:0:2}-annotation.md
-    docker_or_iac=$(if [ "$1" = "docker" ]; then echo "Wiz Docker Image Scan"; else echo "Wiz IaC Scan"; fi)
+    local scan_label
+    case "$1" in
+        docker) scan_label="Wiz Docker Image Scan" ;;
+        iac)    scan_label="Wiz IaC Scan" ;;
+        dir)    scan_label="Wiz Directory Scan" ;;
+        *)      scan_label="Wiz Scan" ;;
+    esac
     pass_or_fail=$(if [ "$3" = "true" ]; then echo 'meets'; else echo 'does not meet'; fi)
-    summary="${docker_or_iac} for ${2} ${pass_or_fail} policy requirements"
-    # we need to create a new file to avoid conflicts, we need scan type, name, pass/fail
+    summary="${scan_label} for ${2} ${pass_or_fail} policy requirements"
     cat <<EOF >>./"${annotation_file}"
 <details>
 <summary>$summary.</summary>
@@ -174,37 +120,36 @@ EOF
     printf "%b\n" "$(cat ./"${annotation_file}")"
 }
 
-# Docker Image Scan
+# Container Image Scan using WizCLI v1 'scan container-image' command.
+# v1 authenticates inline via WIZ_CLIENT_ID/WIZ_CLIENT_SECRET env vars.
 # $1 - Wiz CLI Container Image
-# $2 - Directory with auth file
-# $3 - Image Address
-# $4 - CLI Arguments
+# $2 - Image Address
+# $3+ - CLI Arguments
 function docker_image_scan() {
     local wiz_cli_container_image="${1:-}"
-    local wiz_dir="${2:-}"
-    local image="${3:-}"
-    shift 3
+    local image="${2:-}"
+    shift 2
     local -a cli_args=("${@}")
 
     mkdir -p result
 
-    # make sure local docker has the image
     docker pull "$image"
 
     local -i exit_code=0
     docker run \
         --rm \
-        --mount type=bind,src="$wiz_dir",dst=/cli,readonly \
+        -e WIZ_CLIENT_ID \
+        -e WIZ_CLIENT_SECRET \
         --mount type=bind,src="$PWD",dst=/scan \
         --mount type=bind,src=/var/run/docker.sock,dst=/var/run/docker.sock,readonly \
         "${wiz_cli_container_image}" \
-        docker scan --image "$image" \
-        --policy-hits-only \
+        scan container-image "$image" \
+        --by-policy-hits="BLOCK" \
         "${cli_args[@]}" || exit_code=$?
 
     local image_name
     image_name="$(echo "$image" | cut -d "/" -f 2)"
-    
+
     if [[ $exit_code -eq 0 ]]; then
         build_annotation "docker" "$image_name" true "result/output" | buildkite-agent annotate --append --context 'ctx-wiz-docker-success' --style 'success'
     else
@@ -214,16 +159,14 @@ function docker_image_scan() {
     exit $exit_code
 }
 
-# IaC Scan
+# IaC Scan — routes to v1 'scan dir' with IaC-specific flags.
 # $1 - Wiz CLI Container Image
-# $2 - Directory with auth file
-# $3 - File Path
-# $4 - CLI Arguments
+# $2 - File Path
+# $3+ - CLI Arguments
 function iac_scan() {
     local wiz_cli_container_image="${1:-}"
-    local wiz_dir="${2:-}"
-    local file_path="${3:-}"
-    shift 3
+    local file_path="${2:-}"
+    shift 2
     local -a cli_args=("${@}")
 
     mkdir -p result
@@ -231,37 +174,33 @@ function iac_scan() {
     local -i exit_code=0
     docker run \
         --rm \
-        --mount type=bind,src="$wiz_dir",dst=/cli,readonly \
+        -e WIZ_CLIENT_ID \
+        -e WIZ_CLIENT_SECRET \
         --mount type=bind,src="$PWD",dst=/scan \
         "${wiz_cli_container_image}" \
-        iac scan \
+        scan dir "/scan/$file_path" \
         --name "$BUILDKITE_JOB_ID" \
-        --path "/scan/$file_path" \
         "${cli_args[@]}" || exit_code=$?
 
     if [[ $exit_code -eq 0 ]]; then
         build_annotation "iac" "$BUILDKITE_LABEL" true "result/output" | buildkite-agent annotate --append --context 'ctx-wiz-iac-success' --style 'success'
     else
-        build_annotation "iac" "$BUILDKITE_LABEL" false "result/output" | buildkite-agent annotate --append --context 'ctx-wiz-iac-warning' --style 'warning'    
+        build_annotation "iac" "$BUILDKITE_LABEL" false "result/output" | buildkite-agent annotate --append --context 'ctx-wiz-iac-warning' --style 'warning'
     fi
 
-    # buildkite-agent artifact upload "result/**/*" --log-level info
-    # this post step will be used in template to check the step was run
     echo "${BUILDKITE_BUILD_ID}" >check-file && buildkite-agent artifact upload check-file
 
     exit $exit_code
 }
 
-# Directory Scan
+# Directory Scan using WizCLI v1 'scan dir' command.
 # $1 - Wiz CLI Container Image
-# $2 - Directory with auth file
-# $3 - File Path
-# $4 - CLI Arguments
+# $2 - File Path
+# $3+ - CLI Arguments
 function dir_scan() {
     local wiz_cli_container_image="${1:-}"
-    local wiz_dir="${2:-}"
-    local file_path="${3:-}"
-    shift 3
+    local file_path="${2:-}"
+    shift 2
     local -a cli_args=("${@}")
 
     mkdir -p result
@@ -269,22 +208,20 @@ function dir_scan() {
     local -i exit_code=0
     docker run \
         --rm \
-        --mount type=bind,src="$wiz_dir",dst=/cli,readonly \
+        -e WIZ_CLIENT_ID \
+        -e WIZ_CLIENT_SECRET \
         --mount type=bind,src="$PWD",dst=/scan \
         "${wiz_cli_container_image}" \
-        dir scan \
+        scan dir "/scan/$file_path" \
         --name "$BUILDKITE_JOB_ID" \
-        --path "/scan/$file_path" \
         "${cli_args[@]}" || exit_code=$?
-    
+
     if [[ $exit_code -eq 0 ]]; then
         build_annotation "dir" "$BUILDKITE_LABEL" true "result/output" | buildkite-agent annotate --append --context 'ctx-wiz-dir-success' --style 'success'
     else
         build_annotation "dir" "$BUILDKITE_LABEL" false "result/output" | buildkite-agent annotate --append --context 'ctx-wiz-dir-warning' --style 'warning'
     fi
-    
-    # buildkite-agent artifact upload "result/**/*" --log-level info
-    # this post step will be used in template to check the step was run
+
     echo "${BUILDKITE_BUILD_ID}" >check-file && buildkite-agent artifact upload check-file
 
     exit $exit_code

--- a/lib/plugin.bash
+++ b/lib/plugin.bash
@@ -18,7 +18,7 @@ function build_wiz_cli_args() {
     fi
 
     local scan_formats=("human" "json" "sarif")
-    if [[ ${scan_formats[*]} =~ ${scan_format} ]]; then
+    if in_array "$scan_format" "${scan_formats[@]}"; then
         args+=("--stdout=${scan_format}")
     else
         echo "+++ 🚨 Invalid Scan Format: ${scan_format}" >&2
@@ -32,12 +32,10 @@ function build_wiz_cli_args() {
     # Default file output used for build annotation
     args+=("--human-output-file=/scan/result/output")
 
-    # Declare result array
-    declare -a result
+    local -a result=()
 
-    # Read file output formats into result array
     if plugin_read_list_into_result "BUILDKITE_PLUGIN_WIZ_FILE_OUTPUT_FORMAT"; then
-        declare -A seen_formats
+        local -A seen_formats=()
         for format in "${result[@]}"; do
             if [[ -n "${seen_formats[$format]:-}" ]]; then
                 echo "+++ ⚠️  Duplicate file output format ignored: ${format}"

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,5 +1,5 @@
 name: "Wiz Security Scanner"
-description: Integrates wiz security scanning for infrastructure-as-code and docker images
+description: Integrates Wiz security scanning for infrastructure-as-code, docker images, and directories
 author: https://github.com/blstrco, https://github.com/buildkite-plugins
 public: true
 requirements:

--- a/plugin.yml
+++ b/plugin.yml
@@ -32,7 +32,7 @@ configuration:
         - dir
         - docker
         - iac
-    show-secret-snippets:
+    sensitive-data:
       type: boolean
       default: false
     iac-type:
@@ -40,10 +40,13 @@ configuration:
       enum:
         - Ansible
         - AzureResourceManager
+        - Bicep
         - Cloudformation
         - Dockerfile
+        - GitHubActions
         - GoogleCloudDeploymentManager
         - Kubernetes
+        - Pulumi
         - Terraform
   required:
     - scan-type

--- a/plugin.yml
+++ b/plugin.yml
@@ -32,7 +32,7 @@ configuration:
         - dir
         - docker
         - iac
-    sensitive-data:
+    disable-sensitive-data-scan:
       type: boolean
       default: false
     iac-type:

--- a/tests/plugin.bats
+++ b/tests/plugin.bats
@@ -148,6 +148,16 @@ teardown() {
   assert_output --partial "--types=Terraform"
 }
 
+@test "IaC type with iac scan type" {
+  export BUILDKITE_PLUGIN_WIZ_SCAN_TYPE="iac"
+  export BUILDKITE_PLUGIN_WIZ_IAC_TYPE="Cloudformation"
+
+  run build_wiz_cli_args "$BUILDKITE_PLUGIN_WIZ_SCAN_TYPE"
+
+  assert_success
+  assert_output --partial "--types=Cloudformation"
+}
+
 @test "Sarif and csv-zip file output formats" {
   export BUILDKITE_PLUGIN_WIZ_FILE_OUTPUT_FORMAT_0="sarif"
   export BUILDKITE_PLUGIN_WIZ_FILE_OUTPUT_FORMAT_1="csv-zip"
@@ -167,6 +177,16 @@ teardown() {
 
   assert_success
   assert_output --partial "--parameter-files=variables.tf"
+}
+
+@test "Parameter files with iac scan type" {
+  export BUILDKITE_PLUGIN_WIZ_SCAN_TYPE="iac"
+  export BUILDKITE_PLUGIN_WIZ_PARAMETER_FILES="params.json"
+
+  run build_wiz_cli_args "$BUILDKITE_PLUGIN_WIZ_SCAN_TYPE"
+
+  assert_success
+  assert_output --partial "--parameter-files=params.json"
 }
 
 @test "Get Wiz CLI Container Image" {

--- a/tests/plugin.bats
+++ b/tests/plugin.bats
@@ -122,6 +122,53 @@ teardown() {
   assert_output --partial "--stdout=json --human-output-file=/scan/result/output --human-output-file=/scan/result/output-human --json-output-file=/scan/result/output-json"
 }
 
+@test "Disable sensitive data scan adds --disabled-scanners" {
+  export BUILDKITE_PLUGIN_WIZ_DISABLE_SENSITIVE_DATA_SCAN="true"
+
+  run build_wiz_cli_args "$BUILDKITE_PLUGIN_WIZ_SCAN_TYPE"
+
+  assert_success
+  assert_output --partial "--disabled-scanners=SensitiveData"
+}
+
+@test "Sensitive data scan enabled by default (no --disabled-scanners)" {
+  run build_wiz_cli_args "$BUILDKITE_PLUGIN_WIZ_SCAN_TYPE"
+
+  assert_success
+  refute_output --partial "--disabled-scanners"
+}
+
+@test "IaC type with dir scan type" {
+  export BUILDKITE_PLUGIN_WIZ_SCAN_TYPE="dir"
+  export BUILDKITE_PLUGIN_WIZ_IAC_TYPE="Terraform"
+
+  run build_wiz_cli_args "$BUILDKITE_PLUGIN_WIZ_SCAN_TYPE"
+
+  assert_success
+  assert_output --partial "--types=Terraform"
+}
+
+@test "Sarif and csv-zip file output formats" {
+  export BUILDKITE_PLUGIN_WIZ_FILE_OUTPUT_FORMAT_0="sarif"
+  export BUILDKITE_PLUGIN_WIZ_FILE_OUTPUT_FORMAT_1="csv-zip"
+
+  run build_wiz_cli_args "$BUILDKITE_PLUGIN_WIZ_SCAN_TYPE"
+
+  assert_success
+  assert_output --partial "--sarif-output-file=/scan/result/output-sarif"
+  assert_output --partial "--csv-output-file=/scan/result/output-csv-zip"
+}
+
+@test "Parameter files with dir scan type" {
+  export BUILDKITE_PLUGIN_WIZ_SCAN_TYPE="dir"
+  export BUILDKITE_PLUGIN_WIZ_PARAMETER_FILES="variables.tf"
+
+  run build_wiz_cli_args "$BUILDKITE_PLUGIN_WIZ_SCAN_TYPE"
+
+  assert_success
+  assert_output --partial "--parameter-files=variables.tf"
+}
+
 @test "Get Wiz CLI Container Image" {
   run detect_wiz_cli_container
 

--- a/tests/plugin.bats
+++ b/tests/plugin.bats
@@ -9,17 +9,12 @@ load "${BATS_TEST_DIRNAME}/../lib/shared.bash"
 
 setup() {
   export BUILDKITE_PLUGIN_WIZ_SCAN_TYPE="docker"
-  export WIZ_DIR="$HOME/.wiz"
   export WIZ_CLIENT_ID="test"
   export WIZ_CLIENT_SECRET="secret"
-  export WIZ_CLI_CONTAINER="wiziocli.azurecr.io/wizcli:latest"
+  export WIZ_CLI_CONTAINER="public-registry.wiz.io/wiz-app/wizcli:1"
 }
 
 teardown() {
-  if [ -d "$WIZ_DIR" ]; then
-    rm -rf "$WIZ_DIR"
-  fi
-
   if [ -d result ]; then
     rm -rf result
   fi
@@ -59,37 +54,11 @@ teardown() {
   assert_output "+++ 🚨 The following required environment variables are not set: WIZ_CLIENT_ID WIZ_CLIENT_SECRET"
 }
 
-@test "Successfully authenticate to Wiz" {
-  mkdir -p "$WIZ_DIR"
-  touch "$WIZ_DIR/key"
-
-  stub docker \
-    'run --rm -it --mount type=bind,src="$WIZ_DIR",dst=/cli,readonly -e WIZ_CLIENT_ID -e WIZ_CLIENT_SECRET "wiziocli.azurecr.io/wizcli:latest" auth: exit 0'
-
-  run get_wiz_auth_file "$WIZ_CLI_CONTAINER" "$WIZ_DIR"
-
-  assert_success
-
-  unstub docker
-}
-
-@test "Fail to authenticate to Wiz" {
-  stub docker \
-    'run --rm -it --mount type=bind,src="$WIZ_DIR",dst=/cli,readonly -e WIZ_CLIENT_ID -e WIZ_CLIENT_SECRET "wiziocli.azurecr.io/wizcli:latest" auth: exit 0'
-
-  run get_wiz_auth_file "$WIZ_CLI_CONTAINER" "$WIZ_DIR"
-
-  assert_failure
-  assert_output --partial "Wiz authentication failed, please confirm the credentials are set for WIZ_CLIENT_ID and WIZ_CLIENT_SECRET"
-
-  unstub docker
-}
-
 @test "Invalid Scan Format" {
   export BUILDKITE_PLUGIN_WIZ_SCAN_FORMAT="wrong-format"
 
   run build_wiz_cli_args "$BUILDKITE_PLUGIN_WIZ_SCAN_TYPE"
-  
+
   assert_failure
   assert_output --partial "+++ 🚨 Invalid Scan Format: $BUILDKITE_PLUGIN_WIZ_SCAN_FORMAT"
 }
@@ -98,7 +67,7 @@ teardown() {
   export BUILDKITE_PLUGIN_WIZ_FILE_OUTPUT_FORMAT="wrong-format"
 
   run build_wiz_cli_args "$BUILDKITE_PLUGIN_WIZ_SCAN_TYPE"
-  
+
   assert_failure
   assert_output --partial "+++ 🚨 Invalid File Output Format: $BUILDKITE_PLUGIN_WIZ_FILE_OUTPUT_FORMAT"
 }
@@ -127,7 +96,7 @@ teardown() {
   export BUILDKITE_PLUGIN_WIZ_FILE_OUTPUT_FORMAT_0="human"
   export BUILDKITE_PLUGIN_WIZ_FILE_OUTPUT_FORMAT_1="human"
   export BUILDKITE_PLUGIN_WIZ_FILE_OUTPUT_FORMAT_2="wrong-format"
-  
+
   run build_wiz_cli_args "$BUILDKITE_PLUGIN_WIZ_SCAN_TYPE"
 
   assert_failure
@@ -139,7 +108,7 @@ teardown() {
   run build_wiz_cli_args "$BUILDKITE_PLUGIN_WIZ_SCAN_TYPE"
 
   assert_success
-  assert_output --partial "--format=human --output=/scan/result/output,human"
+  assert_output --partial "--stdout=human --human-output-file=/scan/result/output"
 }
 
 @test "Valid Wiz CLI Args (custom)" {
@@ -150,44 +119,18 @@ teardown() {
   run build_wiz_cli_args "$BUILDKITE_PLUGIN_WIZ_SCAN_TYPE"
 
   assert_success
-  assert_output --partial "--format=json --output=/scan/result/output,human --output=/scan/result/output-human,human --output=/scan/result/output-json,json"
+  assert_output --partial "--stdout=json --human-output-file=/scan/result/output --human-output-file=/scan/result/output-human --json-output-file=/scan/result/output-json"
 }
 
-@test "Get Wiz CLI Container Image (amd64)" {
-  stub uname "-m : echo 'x86_64'"
-
+@test "Get Wiz CLI Container Image" {
   run detect_wiz_cli_container
 
   assert_success
-  assert_output --partial "wiziocli.azurecr.io/wizcli:latest-amd64"
-
-  unstub uname
+  assert_output "public-registry.wiz.io/wiz-app/wizcli:1"
 }
 
-@test "Get Wiz CLI Container Image (arm64)" {
-  stub uname "-m : echo 'arm64'"
+@test "Build Annotations for docker scan (no findings)" {
 
-  run detect_wiz_cli_container
-
-  assert_success
-  assert_output --partial "wiziocli.azurecr.io/wizcli:latest-arm64"
-
-  unstub uname
-}
-
-@test "Get Wiz CLI Container Image (unknown architecture)" {
-  stub uname "-m : echo 'unknown'"
-
-  run detect_wiz_cli_container
-
-  assert_success
-  assert_output --partial "wiziocli.azurecr.io/wizcli:latest"
-
-  unstub uname
-}
-
-@test "Build Annotations (no findings)" {
-  
   run build_annotation "docker" "ubuntu:latest" true "result/output"
 
   assert_success
@@ -195,7 +138,7 @@ teardown() {
   assert_output --partial "<summary>Wiz Docker Image Scan for ubuntu:latest meets policy requirements.</summary>"
 }
 
-@test "Build Annotations (findings)" {
+@test "Build Annotations for docker scan (findings)" {
 
   run build_annotation "docker" "ubuntu:latest" false "result/output"
 
@@ -204,23 +147,39 @@ teardown() {
   assert_output --partial "<summary>Wiz Docker Image Scan for ubuntu:latest does not meet policy requirements.</summary>"
 }
 
+@test "Build Annotations for iac scan" {
+
+  run build_annotation "iac" "my-stack" true "result/output"
+
+  assert_success
+
+  assert_output --partial "<summary>Wiz IaC Scan for my-stack meets policy requirements.</summary>"
+}
+
+@test "Build Annotations for dir scan" {
+
+  run build_annotation "dir" "my-dir" true "result/output"
+
+  assert_success
+
+  assert_output --partial "<summary>Wiz Directory Scan for my-dir meets policy requirements.</summary>"
+}
+
 @test "Docker Scan (success)" {
   export BUILDKITE_PLUGIN_WIZ_IMAGE_ADDRESS="ubuntu:latest"
-  export cli_args=("--format=human" "--output=/scan/result/output,human")
-
-  mkdir -p "$WIZ_DIR"
+  export cli_args=("--stdout=human" "--human-output-file=/scan/result/output")
 
   mkdir -p "result"
   touch "result/output"
 
   stub docker \
     'pull "ubuntu:latest" : exit 0' \
-    'run --rm --mount type=bind,src=/root/.wiz,dst=/cli,readonly --mount type=bind,src=/plugin,dst=/scan --mount type=bind,src=/var/run/docker.sock,dst=/var/run/docker.sock,readonly wiziocli.azurecr.io/wizcli:latest docker scan --image ubuntu:latest --policy-hits-only --format=human --output=/scan/result/output,human : echo "Docker image scanned without policy hits"'
+    'run --rm -e WIZ_CLIENT_ID -e WIZ_CLIENT_SECRET --mount type=bind,src=/plugin,dst=/scan --mount type=bind,src=/var/run/docker.sock,dst=/var/run/docker.sock,readonly public-registry.wiz.io/wiz-app/wizcli:1 scan container-image ubuntu:latest --by-policy-hits=BLOCK --stdout=human --human-output-file=/scan/result/output : echo "Docker image scanned without policy hits"'
 
   stub buildkite-agent \
     'annotate --append --context 'ctx-wiz-docker-success' --style 'success' : echo "Annotated Build"'
 
-  run docker_image_scan "${WIZ_CLI_CONTAINER}" "${WIZ_DIR}" "${BUILDKITE_PLUGIN_WIZ_IMAGE_ADDRESS}" "${cli_args[@]}"
+  run docker_image_scan "${WIZ_CLI_CONTAINER}" "${BUILDKITE_PLUGIN_WIZ_IMAGE_ADDRESS}" "${cli_args[@]}"
 
   assert_success
 
@@ -233,24 +192,22 @@ teardown() {
 
 @test "Docker Scan (failure)" {
   export BUILDKITE_PLUGIN_WIZ_IMAGE_ADDRESS="ubuntu:latest"
-  export cli_args=("--format=human" "--output=/scan/result/output,human")
-
-  mkdir -p "$WIZ_DIR"
+  export cli_args=("--stdout=human" "--human-output-file=/scan/result/output")
 
   mkdir -p "result"
   touch "result/output"
 
   stub docker \
     'pull "ubuntu:latest" : exit 0' \
-    'run --rm --mount type=bind,src=/root/.wiz,dst=/cli,readonly --mount type=bind,src=/plugin,dst=/scan --mount type=bind,src=/var/run/docker.sock,dst=/var/run/docker.sock,readonly wiziocli.azurecr.io/wizcli:latest docker scan --image ubuntu:latest --policy-hits-only --format=human --output=/scan/result/output,human : echo "Docker image scanned with policy hits"; exit 1'
-  
+    'run --rm -e WIZ_CLIENT_ID -e WIZ_CLIENT_SECRET --mount type=bind,src=/plugin,dst=/scan --mount type=bind,src=/var/run/docker.sock,dst=/var/run/docker.sock,readonly public-registry.wiz.io/wiz-app/wizcli:1 scan container-image ubuntu:latest --by-policy-hits=BLOCK --stdout=human --human-output-file=/scan/result/output : echo "Docker image scanned with policy hits"; exit 1'
+
   stub buildkite-agent \
     'annotate --append --context 'ctx-wiz-docker-warning' --style 'warning' : echo "Annotated Build"'
 
-  run docker_image_scan "${WIZ_CLI_CONTAINER}" "${WIZ_DIR}" "${BUILDKITE_PLUGIN_WIZ_IMAGE_ADDRESS}" "${cli_args[@]}"
+  run docker_image_scan "${WIZ_CLI_CONTAINER}" "${BUILDKITE_PLUGIN_WIZ_IMAGE_ADDRESS}" "${cli_args[@]}"
 
   assert_failure
-  
+
   assert_output --partial "Docker image scanned with policy hits"
   assert_output --partial "Annotated Build"
 
@@ -263,21 +220,19 @@ teardown() {
   export BUILDKITE_BUILD_ID="1234-abcd"
   export BUILDKITE_LABEL="iac-scan"
   export FILE_PATH="iac/to/scan"
-  export cli_args=("--format=human" "--output=/scan/result/output,human")
-
-  mkdir -p "$WIZ_DIR"
+  export cli_args=("--stdout=human" "--human-output-file=/scan/result/output")
 
   mkdir -p "result"
   touch "result/output"
 
   stub docker \
-    'run --rm --mount type=bind,src=/root/.wiz,dst=/cli,readonly --mount type=bind,src=/plugin,dst=/scan wiziocli.azurecr.io/wizcli:latest iac scan --name 1234-abcd --path /scan/iac/to/scan --format=human --output=/scan/result/output,human : echo "IaC scanned without policy hits"'
+    'run --rm -e WIZ_CLIENT_ID -e WIZ_CLIENT_SECRET --mount type=bind,src=/plugin,dst=/scan public-registry.wiz.io/wiz-app/wizcli:1 scan dir /scan/iac/to/scan --name 1234-abcd --stdout=human --human-output-file=/scan/result/output : echo "IaC scanned without policy hits"'
 
   stub buildkite-agent \
     'annotate --append --context 'ctx-wiz-iac-success' --style 'success' : echo "Annotated Build"' \
     'artifact upload check-file : echo "Uploaded check-file"'
 
-  run iac_scan "${WIZ_CLI_CONTAINER}" "${WIZ_DIR}" "${FILE_PATH}" "${cli_args[@]}"
+  run iac_scan "${WIZ_CLI_CONTAINER}" "${FILE_PATH}" "${cli_args[@]}"
 
   assert_success
 
@@ -294,21 +249,19 @@ teardown() {
   export BUILDKITE_BUILD_ID="1234-abcd"
   export BUILDKITE_LABEL="iac-scan"
   export FILE_PATH="iac/to/scan"
-  export cli_args=("--format=human" "--output=/scan/result/output,human")
-
-  mkdir -p "$WIZ_DIR"
+  export cli_args=("--stdout=human" "--human-output-file=/scan/result/output")
 
   mkdir -p "result"
   touch "result/output"
 
   stub docker \
-    'run --rm --mount type=bind,src=/root/.wiz,dst=/cli,readonly --mount type=bind,src=/plugin,dst=/scan wiziocli.azurecr.io/wizcli:latest iac scan --name 1234-abcd --path /scan/iac/to/scan --format=human --output=/scan/result/output,human : echo "IaC scanned with policy hits"; exit 1'
+    'run --rm -e WIZ_CLIENT_ID -e WIZ_CLIENT_SECRET --mount type=bind,src=/plugin,dst=/scan public-registry.wiz.io/wiz-app/wizcli:1 scan dir /scan/iac/to/scan --name 1234-abcd --stdout=human --human-output-file=/scan/result/output : echo "IaC scanned with policy hits"; exit 1'
 
   stub buildkite-agent \
     'annotate --append --context 'ctx-wiz-iac-warning' --style 'warning' : echo "Annotated Build"' \
     'artifact upload check-file : echo "Uploaded check-file"'
 
-  run iac_scan "${WIZ_CLI_CONTAINER}" "${WIZ_DIR}" "${FILE_PATH}" "${cli_args[@]}"
+  run iac_scan "${WIZ_CLI_CONTAINER}" "${FILE_PATH}" "${cli_args[@]}"
 
   assert_failure
 
@@ -323,23 +276,21 @@ teardown() {
 @test "Directory Scan (success)" {
   export BUILDKITE_JOB_ID="1234-abcd"
   export BUILDKITE_BUILD_ID="1234-abcd"
-  export BUILDKITE_LABEL="iac-scan"
+  export BUILDKITE_LABEL="dir-scan"
   export FILE_PATH="dir/to/scan"
-  export cli_args=("--format=human" "--output=/scan/result/output,human")
-
-  mkdir -p "$WIZ_DIR"
+  export cli_args=("--stdout=human" "--human-output-file=/scan/result/output")
 
   mkdir -p "result"
   touch "result/output"
 
   stub docker \
-    'run --rm --mount type=bind,src=/root/.wiz,dst=/cli,readonly --mount type=bind,src=/plugin,dst=/scan wiziocli.azurecr.io/wizcli:latest dir scan --name 1234-abcd --path /scan/dir/to/scan --format=human --output=/scan/result/output,human : echo "Directory scanned without policy hits"'
+    'run --rm -e WIZ_CLIENT_ID -e WIZ_CLIENT_SECRET --mount type=bind,src=/plugin,dst=/scan public-registry.wiz.io/wiz-app/wizcli:1 scan dir /scan/dir/to/scan --name 1234-abcd --stdout=human --human-output-file=/scan/result/output : echo "Directory scanned without policy hits"'
 
   stub buildkite-agent \
     'annotate --append --context 'ctx-wiz-dir-success' --style 'success' : echo "Annotated Build"' \
     'artifact upload check-file : echo "Uploaded check-file"'
 
-  run dir_scan "${WIZ_CLI_CONTAINER}" "${WIZ_DIR}" "${FILE_PATH}" "${cli_args[@]}"
+  run dir_scan "${WIZ_CLI_CONTAINER}" "${FILE_PATH}" "${cli_args[@]}"
 
   assert_success
 
@@ -354,30 +305,28 @@ teardown() {
 @test "Directory Scan (failure)" {
   export BUILDKITE_JOB_ID="1234-abcd"
   export BUILDKITE_BUILD_ID="1234-abcd"
-  export BUILDKITE_LABEL="iac-scan"
+  export BUILDKITE_LABEL="dir-scan"
   export FILE_PATH="dir/to/scan"
-  export cli_args=("--format=human" "--output=/scan/result/output,human")
-
-  mkdir -p "$WIZ_DIR"
+  export cli_args=("--stdout=human" "--human-output-file=/scan/result/output")
 
   mkdir -p "result"
   touch "result/output"
 
   stub docker \
-    'run --rm --mount type=bind,src=/root/.wiz,dst=/cli,readonly --mount type=bind,src=/plugin,dst=/scan wiziocli.azurecr.io/wizcli:latest dir scan --name 1234-abcd --path /scan/dir/to/scan --format=human --output=/scan/result/output,human : echo "Directory scanned with policy hits"; exit 1'
-  
+    'run --rm -e WIZ_CLIENT_ID -e WIZ_CLIENT_SECRET --mount type=bind,src=/plugin,dst=/scan public-registry.wiz.io/wiz-app/wizcli:1 scan dir /scan/dir/to/scan --name 1234-abcd --stdout=human --human-output-file=/scan/result/output : echo "Directory scanned with policy hits"; exit 1'
+
   stub buildkite-agent \
     'annotate --append --context 'ctx-wiz-dir-warning' --style 'warning' : echo "Annotated Build"' \
     'artifact upload check-file : echo "Uploaded check-file"'
-  
-  run dir_scan "${WIZ_CLI_CONTAINER}" "${WIZ_DIR}" "${FILE_PATH}" "${cli_args[@]}"
-  
+
+  run dir_scan "${WIZ_CLI_CONTAINER}" "${FILE_PATH}" "${cli_args[@]}"
+
   assert_failure
-  
+
   assert_output --partial "Directory scanned with policy hits"
   assert_output --partial "Annotated Build"
   assert_output --partial "Uploaded check-file"
-  
+
   unstub docker
   unstub buildkite-agent
 }

--- a/tests/plugin.bats
+++ b/tests/plugin.bats
@@ -221,7 +221,7 @@ teardown() {
 
   stub docker \
     'pull "ubuntu:latest" : exit 0' \
-    'run --rm -e WIZ_CLIENT_ID -e WIZ_CLIENT_SECRET --mount type=bind,src=/plugin,dst=/scan --mount type=bind,src=/var/run/docker.sock,dst=/var/run/docker.sock,readonly public-registry.wiz.io/wiz-app/wizcli:1 scan container-image ubuntu:latest --by-policy-hits=BLOCK --stdout=human --human-output-file=/scan/result/output : echo "Docker image scanned without policy hits"'
+    'run --rm -e WIZ_CLIENT_ID -e WIZ_CLIENT_SECRET --mount type=bind,src=/plugin,dst=/scan --mount type=bind,src=/var/run/docker.sock,dst=/var/run/docker.sock,readonly public-registry.wiz.io/wiz-app/wizcli:1 scan container-image ubuntu:latest --stdout=human --human-output-file=/scan/result/output : echo "Docker image scanned without policy hits"'
 
   stub buildkite-agent \
     'annotate --append --context 'ctx-wiz-docker-success' --style 'success' : echo "Annotated Build"'
@@ -246,7 +246,7 @@ teardown() {
 
   stub docker \
     'pull "ubuntu:latest" : exit 0' \
-    'run --rm -e WIZ_CLIENT_ID -e WIZ_CLIENT_SECRET --mount type=bind,src=/plugin,dst=/scan --mount type=bind,src=/var/run/docker.sock,dst=/var/run/docker.sock,readonly public-registry.wiz.io/wiz-app/wizcli:1 scan container-image ubuntu:latest --by-policy-hits=BLOCK --stdout=human --human-output-file=/scan/result/output : echo "Docker image scanned with policy hits"; exit 1'
+    'run --rm -e WIZ_CLIENT_ID -e WIZ_CLIENT_SECRET --mount type=bind,src=/plugin,dst=/scan --mount type=bind,src=/var/run/docker.sock,dst=/var/run/docker.sock,readonly public-registry.wiz.io/wiz-app/wizcli:1 scan container-image ubuntu:latest --stdout=human --human-output-file=/scan/result/output : echo "Docker image scanned with policy hits"; exit 1'
 
   stub buildkite-agent \
     'annotate --append --context 'ctx-wiz-docker-warning' --style 'warning' : echo "Annotated Build"'

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -56,7 +56,7 @@ teardown() {
 
   stub docker \
     'pull "ubuntu:22.04" : exit 0' \
-    'run --rm -e WIZ_CLIENT_ID -e WIZ_CLIENT_SECRET --mount type=bind,src=/plugin,dst=/scan --mount type=bind,src=/var/run/docker.sock,dst=/var/run/docker.sock,readonly public-registry.wiz.io/wiz-app/wizcli:1 scan container-image ubuntu:22.04 --by-policy-hits=BLOCK --stdout=human --human-output-file=/scan/result/output : echo "Docker image scanned without policy hits"'
+    'run --rm -e WIZ_CLIENT_ID -e WIZ_CLIENT_SECRET --mount type=bind,src=/plugin,dst=/scan --mount type=bind,src=/var/run/docker.sock,dst=/var/run/docker.sock,readonly public-registry.wiz.io/wiz-app/wizcli:1 scan container-image ubuntu:22.04 --stdout=human --human-output-file=/scan/result/output : echo "Docker image scanned without policy hits"'
 
   stub buildkite-agent \
     'annotate --append --context 'ctx-wiz-docker-success' --style 'success' : echo "Annotated Build"'

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -138,6 +138,28 @@ teardown() {
   unstub buildkite-agent
 }
 
+@test "Directory Scan with disable-sensitive-data-scan" {
+  export BUILDKITE_PLUGIN_WIZ_SCAN_TYPE="dir"
+  export BUILDKITE_PLUGIN_WIZ_PATH="dir/to/scan"
+  export BUILDKITE_PLUGIN_WIZ_DISABLE_SENSITIVE_DATA_SCAN="true"
+
+  stub docker \
+    'run --rm -e WIZ_CLIENT_ID -e WIZ_CLIENT_SECRET --mount type=bind,src=/plugin,dst=/scan public-registry.wiz.io/wiz-app/wizcli:1 scan dir /scan/dir/to/scan --name 1234-abcd --disabled-scanners=SensitiveData --stdout=human --human-output-file=/scan/result/output : echo "Directory scanned without policy hits"'
+
+  stub buildkite-agent \
+    'annotate --append --context 'ctx-wiz-dir-success' --style 'success' : echo "Annotated Build"' \
+    'artifact upload check-file : echo "Uploaded check-file"'
+
+  run "$PWD/hooks/post-command"
+
+  assert_success
+
+  assert_output --partial "Directory scanned without policy hits"
+
+  unstub docker
+  unstub buildkite-agent
+}
+
 @test "Directory Scan with Invalid Scan Format" {
   export BUILDKITE_PLUGIN_WIZ_SCAN_TYPE="dir"
   export BUILDKITE_PLUGIN_WIZ_PATH="dir/to/scan"

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -118,6 +118,26 @@ teardown() {
   unstub buildkite-agent
 }
 
+@test "Directory Scan defaults path to current directory" {
+  export BUILDKITE_PLUGIN_WIZ_SCAN_TYPE="dir"
+
+  stub docker \
+    'run --rm -e WIZ_CLIENT_ID -e WIZ_CLIENT_SECRET --mount type=bind,src=/plugin,dst=/scan public-registry.wiz.io/wiz-app/wizcli:1 scan dir /scan/. --name 1234-abcd --stdout=human --human-output-file=/scan/result/output : echo "Directory scanned without policy hits"'
+
+  stub buildkite-agent \
+    'annotate --append --context 'ctx-wiz-dir-success' --style 'success' : echo "Annotated Build"' \
+    'artifact upload check-file : echo "Uploaded check-file"'
+
+  run "$PWD/hooks/post-command"
+
+  assert_success
+
+  assert_output --partial "Directory scanned without policy hits"
+
+  unstub docker
+  unstub buildkite-agent
+}
+
 @test "Directory Scan with Invalid Scan Format" {
   export BUILDKITE_PLUGIN_WIZ_SCAN_TYPE="dir"
   export BUILDKITE_PLUGIN_WIZ_PATH="dir/to/scan"

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -9,19 +9,14 @@ load "${BATS_TEST_DIRNAME}/../lib/shared.bash"
 # export BUILDKITE_AGENT_STUB_DEBUG=/dev/tty
 
 setup() {
-  export WIZ_DIR="$HOME/.wiz"
   export WIZ_CLIENT_ID="test"
   export WIZ_CLIENT_SECRET="secret"
   export BUILDKITE_JOB_ID="1234-abcd"
   export BUILDKITE_BUILD_ID="1234-abcd"
-  export BUILDKITE_LABEL="iac-scan"
+  export BUILDKITE_LABEL="scan-step"
 }
 
 teardown() {
-  if [ -d "$WIZ_DIR" ]; then
-    rm -rf "$WIZ_DIR"
-  fi
-
   if [ -d result ]; then
     rm -rf result
   fi
@@ -59,28 +54,20 @@ teardown() {
   export BUILDKITE_PLUGIN_WIZ_SCAN_TYPE="docker"
   export BUILDKITE_PLUGIN_WIZ_IMAGE_ADDRESS="ubuntu:22.04"
 
-  stub uname "-m : echo 'unknown'"
-
-  mkdir -p "$WIZ_DIR"
-  touch "$WIZ_DIR/key"
-
   stub docker \
-    'run --rm --mount type=bind,src=/root/.wiz,dst=/cli -e WIZ_CLIENT_ID -e WIZ_CLIENT_SECRET wiziocli.azurecr.io/wizcli:latest auth : exit 0' \
     'pull "ubuntu:22.04" : exit 0' \
-    'run --rm --mount type=bind,src=/root/.wiz,dst=/cli,readonly --mount type=bind,src=/plugin,dst=/scan --mount type=bind,src=/var/run/docker.sock,dst=/var/run/docker.sock,readonly wiziocli.azurecr.io/wizcli:latest docker scan --image ubuntu:22.04 --policy-hits-only --format=human --output=/scan/result/output,human : echo "Docker image scanned without policy hits"'
-  
+    'run --rm -e WIZ_CLIENT_ID -e WIZ_CLIENT_SECRET --mount type=bind,src=/plugin,dst=/scan --mount type=bind,src=/var/run/docker.sock,dst=/var/run/docker.sock,readonly public-registry.wiz.io/wiz-app/wizcli:1 scan container-image ubuntu:22.04 --by-policy-hits=BLOCK --stdout=human --human-output-file=/scan/result/output : echo "Docker image scanned without policy hits"'
+
   stub buildkite-agent \
     'annotate --append --context 'ctx-wiz-docker-success' --style 'success' : echo "Annotated Build"'
 
   run "$PWD/hooks/post-command"
-  
+
   assert_success
 
-  assert_output --partial "Authenticated successfully"
   assert_output --partial "Docker image scanned without policy hits"
   assert_output --partial "Annotated Build"
 
-  unstub uname
   unstub docker
   unstub buildkite-agent
 }
@@ -89,29 +76,21 @@ teardown() {
   export BUILDKITE_PLUGIN_WIZ_SCAN_TYPE="iac"
   export BUILDKITE_PLUGIN_WIZ_PATH="iac/to/scan"
 
-  stub uname "-m : echo 'unknown'"
-
-  mkdir -p "$WIZ_DIR"
-  touch "$WIZ_DIR/key"
-
   stub docker \
-    'run --rm --mount type=bind,src=/root/.wiz,dst=/cli -e WIZ_CLIENT_ID -e WIZ_CLIENT_SECRET wiziocli.azurecr.io/wizcli:latest auth : exit 0' \
-    'run --rm --mount type=bind,src=/root/.wiz,dst=/cli,readonly --mount type=bind,src=/plugin,dst=/scan wiziocli.azurecr.io/wizcli:latest iac scan --name 1234-abcd --path /scan/iac/to/scan --format=human --output=/scan/result/output,human : echo "IaC scanned without policy hits"'
-  
+    'run --rm -e WIZ_CLIENT_ID -e WIZ_CLIENT_SECRET --mount type=bind,src=/plugin,dst=/scan public-registry.wiz.io/wiz-app/wizcli:1 scan dir /scan/iac/to/scan --name 1234-abcd --stdout=human --human-output-file=/scan/result/output : echo "IaC scanned without policy hits"'
+
   stub buildkite-agent \
     'annotate --append --context 'ctx-wiz-iac-success' --style 'success' : echo "Annotated Build"' \
     'artifact upload check-file : echo "Uploaded check-file"'
 
   run "$PWD/hooks/post-command"
-  
+
   assert_success
 
-  assert_output --partial "Authenticated successfully"
   assert_output --partial "IaC scanned without policy hits"
   assert_output --partial "Annotated Build"
   assert_output --partial "Uploaded check-file"
 
-  unstub uname
   unstub docker
   unstub buildkite-agent
 }
@@ -120,29 +99,21 @@ teardown() {
   export BUILDKITE_PLUGIN_WIZ_SCAN_TYPE="dir"
   export BUILDKITE_PLUGIN_WIZ_PATH="dir/to/scan"
 
-  stub uname "-m : echo 'unknown'"
-
-  mkdir -p "$WIZ_DIR"
-  touch "$WIZ_DIR/key"
-
   stub docker \
-    'run --rm --mount type=bind,src=/root/.wiz,dst=/cli -e WIZ_CLIENT_ID -e WIZ_CLIENT_SECRET wiziocli.azurecr.io/wizcli:latest auth : exit 0' \
-    'run --rm --mount type=bind,src=/root/.wiz,dst=/cli,readonly --mount type=bind,src=/plugin,dst=/scan wiziocli.azurecr.io/wizcli:latest dir scan --name 1234-abcd --path /scan/dir/to/scan --format=human --output=/scan/result/output,human : echo "Directory scanned without policy hits"'
-  
+    'run --rm -e WIZ_CLIENT_ID -e WIZ_CLIENT_SECRET --mount type=bind,src=/plugin,dst=/scan public-registry.wiz.io/wiz-app/wizcli:1 scan dir /scan/dir/to/scan --name 1234-abcd --stdout=human --human-output-file=/scan/result/output : echo "Directory scanned without policy hits"'
+
   stub buildkite-agent \
     'annotate --append --context 'ctx-wiz-dir-success' --style 'success' : echo "Annotated Build"' \
     'artifact upload check-file : echo "Uploaded check-file"'
 
   run "$PWD/hooks/post-command"
-  
+
   assert_success
 
-  assert_output --partial "Authenticated successfully"
   assert_output --partial "Directory scanned without policy hits"
   assert_output --partial "Annotated Build"
   assert_output --partial "Uploaded check-file"
 
-  unstub uname
   unstub docker
   unstub buildkite-agent
 }
@@ -153,7 +124,7 @@ teardown() {
   export BUILDKITE_PLUGIN_WIZ_SCAN_FORMAT="invalid"
 
   run "$PWD/hooks/post-command"
-  
+
   assert_failure
 
   assert_output --partial "+++ 🚨 Invalid Scan Format: invalid"
@@ -166,7 +137,7 @@ teardown() {
   export BUILDKITE_PLUGIN_WIZ_FILE_OUTPUT_FORMAT="invalid"
 
   run "$PWD/hooks/post-command"
-  
+
   assert_failure
 
   assert_output --partial "+++ 🚨 Invalid File Output Format: invalid"
@@ -180,7 +151,7 @@ teardown() {
   unset WIZ_CLIENT_SECRET
 
   run "$PWD/hooks/post-command"
-  
+
   assert_failure
 
   assert_output --partial "+++ 🚨 The following required environment variables are not set: WIZ_CLIENT_ID WIZ_CLIENT_SECRET"


### PR DESCRIPTION
- Migrate from WizCLI v0.x to v1.x (v0.x End of Support is April 15, 2026)
  - Uses new container registry and image for v1
- Update all scan commands, CLI flags, and container image to v1 equivalents
- Remove separate auth step; v1 authenticates inline via env vars
- Replace `show-secret-snippets` with `disable-sensitive-data-scan` (v1 enables sensitive data scanning by default)
- Fix image name extraction bug for multi-segment registry paths
- Default `path` to `.` explicitly for dir/iac scans
- Various bash-specific improvements