### PR TITLE
Support marking Wiz scans with tags for ease of filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,10 @@ Defaults to: repository root (`.`)
 Disable the sensitive data scanner (PII, PCI, PHI detection). WizCLI v1 enables this scanner by default.
 Defaults to: `false`
 
+### `tags` (Optional, string or array)
+
+List of tags to mark the scan with. The format of a tag can be KEY or KEY=VALUE.
+
 ## Developing
 
 To run the tests:

--- a/lib/plugin.bash
+++ b/lib/plugin.bash
@@ -17,6 +17,13 @@ function build_wiz_cli_args() {
         args+=("--disabled-scanners=SensitiveData")
     fi
 
+    # Tags can be set for all scan types
+    if plugin_read_list_into_result "BUILDKITE_PLUGIN_WIZ_TAGS"; then
+        if [ ${#result[@]} -gt 0 ]; then
+            args+=("--tags=$(IFS=,; echo "${result[*]}")")
+        fi
+    fi
+
     local scan_formats=("human" "json" "sarif")
     if in_array "$scan_format" "${scan_formats[@]}"; then
         args+=("--stdout=${scan_format}")

--- a/plugin.yml
+++ b/plugin.yml
@@ -35,6 +35,8 @@ configuration:
     disable-sensitive-data-scan:
       type: boolean
       default: false
+    tags:
+      type: [string, array]
     iac-type:
       type: string
       enum:

--- a/tests/plugin.bats
+++ b/tests/plugin.bats
@@ -138,6 +138,26 @@ teardown() {
   refute_output --partial "--disabled-scanners"
 }
 
+@test "Add tags to the scan from a comma separated string" {
+  export BUILDKITE_PLUGIN_WIZ_TAGS="tag1=test1,tag2=test2,tag3"
+
+  run build_wiz_cli_args "$BUILDKITE_PLUGIN_WIZ_SCAN_TYPE"
+
+  assert_success
+  assert_output --partial "--tags=tag1=test1,tag2=test2,tag3"
+}
+
+@test "Add tags to the scan from an array" {
+  export BUILDKITE_PLUGIN_WIZ_TAGS_0="tag1=test1"
+  export BUILDKITE_PLUGIN_WIZ_TAGS_1="tag2=test2"
+  export BUILDKITE_PLUGIN_WIZ_TAGS_2="tag3"
+
+  run build_wiz_cli_args "$BUILDKITE_PLUGIN_WIZ_SCAN_TYPE"
+
+  assert_success
+  assert_output --partial "--tags=tag1=test1,tag2=test2,tag3"
+}
+
 @test "IaC type with dir scan type" {
   export BUILDKITE_PLUGIN_WIZ_SCAN_TYPE="dir"
   export BUILDKITE_PLUGIN_WIZ_IAC_TYPE="Terraform"

--- a/tests/post-command.bats
+++ b/tests/post-command.bats
@@ -160,6 +160,28 @@ teardown() {
   unstub buildkite-agent
 }
 
+@test "Directory Scan with tags set" {
+  export BUILDKITE_PLUGIN_WIZ_SCAN_TYPE="dir"
+  export BUILDKITE_PLUGIN_WIZ_PATH="dir/to/scan"
+  export BUILDKITE_PLUGIN_WIZ_TAGS="tag1=test1,tag2=test2,tag3"
+
+  stub docker \
+    'run --rm -e WIZ_CLIENT_ID -e WIZ_CLIENT_SECRET --mount type=bind,src=/plugin,dst=/scan public-registry.wiz.io/wiz-app/wizcli:1 scan dir /scan/dir/to/scan --name 1234-abcd --tags=tag1=test1,tag2=test2,tag3 --stdout=human --human-output-file=/scan/result/output : echo "Directory scanned without policy hits"'
+
+  stub buildkite-agent \
+    'annotate --append --context 'ctx-wiz-dir-success' --style 'success' : echo "Annotated Build"' \
+    'artifact upload check-file : echo "Uploaded check-file"'
+
+  run "$PWD/hooks/post-command"
+
+  assert_success
+
+  assert_output --partial "Directory scanned without policy hits"
+
+  unstub docker
+  unstub buildkite-agent
+}
+
 @test "Directory Scan with Invalid Scan Format" {
   export BUILDKITE_PLUGIN_WIZ_SCAN_TYPE="dir"
   export BUILDKITE_PLUGIN_WIZ_PATH="dir/to/scan"


### PR DESCRIPTION
When there are a lot of builds it can be useful to filter scanned assets with tags. This PR adds a `tags` configuration which can be used to set this.

All tests pass locally with `docker compose run --rm tests`

Additionally a test was run against an image with Wiz by calling the `post-command` directly:
```bash
BUILDKITE_PLUGIN_WIZ_SCAN_TYPE=docker BUILDKITE_PLUGIN_WIZ_IMAGE_ADDRESS=<image> BUILDKITE_PLUGIN_WIZ_TAGS="tag1=test1,tag2=test2,tag3" ./post-command
```
the tags were verified to be present as expected in Wiz:
<img width="354" height="78" alt="Screenshot 2026-04-22 at 17 09 58" src="https://github.com/user-attachments/assets/80abc4df-0a23-4756-9cf4-8036f7a8626a" />
